### PR TITLE
Rely more upon Specref

### DIFF
--- a/biblio.js
+++ b/biblio.js
@@ -35,18 +35,6 @@ var biblio = {
 			"http://www.w3.org/WAI/ARIA/"
 		]
 	},
-	// Correct reference for ATK
-	"ATK": {
-		"href": "https://developer.gnome.org/atk/stable/",
-		"title": "ATK - Accessibility Toolkit",
-		"publisher": "The GNOME Project"
-	},
-	// Custom reference for the Mac OSX Accessibility API
-	"AXAPI": {
-		"href": "https://developer.apple.com/library/content/documentation/Accessibility/Conceptual/AccessibilityMacOSX/index.html#//apple_ref/doc/uid/TP40001078",
-		"title": "Accessibility Programming Guide for OS X",
-		"publisher": "Apple Corporation"
-	},
 	"CORE-AAM": {
 		"title": "Core Accessibility API Mappings 1.1",
 		"href": "http://www.w3.org/TR/core-aam-1.1/",
@@ -112,23 +100,10 @@ var biblio = {
                         "http://www.w3.org/SVG/"
                 ]
         },
-
-	"EPUB-SSV": {
-		"href": "http://www.idpf.org/epub/vocab/structure/",
-		"title": "EPUB Structural Semantics Vocabulary",
-		"publisher": "IDPF"
-	},
-
 	"EPUB-Content": {
 		"href": "http://www.idpf.org/epub/31/spec/epub-contentdocs.html",
 		"title": "EPUB Content Documents 3.1",
 		"publisher": "IDPF"
-	},
-	// Custom reference for GTK+ (GNOME GUI Toolkit) (not available from SpecRef biblio)
-	"GTK": {
-		"href": "https://developer.gnome.org/gtk3/stable/",
-		"title": "GTK+ 3 Reference Manual",
-		"publisher": "The GNOME Project"
 	},
 	"HTML-AAM": {
 		"authors": [
@@ -146,11 +121,6 @@ var biblio = {
 			"http://www.w3.org/html",
 			"http://www.w3.org/WAI/PF/"
 		]
-	},
-	"MSAA": {
-		"href": "https://msdn.microsoft.com/en-us/library/ms697707.aspx",
-		"title": "Microsoft Active Accessibility (MSAA) 2.0",
-		"publisher": "Microsoft Corporation"
 	},
 	"SVG-AAM": {
 		"title": "SVG2 Accessibility API Mappings 1.0",
@@ -179,65 +149,6 @@ var biblio = {
 		"http://www.w3.org/SVG"
 		]
 	},
-	"SVG11": {
-		"title": "Scalable Vector Graphics (SVG) 1.1 (Second Edition)",
-		"href": "http://www.w3.org/TR/SVG11/",
-		"status": "REC",
-		"publisher": "W3C",
-		"authors": [
-			"Erik Dahlström",
-			"Patrick Dengler",
-			"Anthony Grasso",
-			"Chris Lilley",
-			"Cameron McCormack",
-			"Doug Schepers",
-			"Jonathan Watt",
-			"John Ferraiolo",
-			"藤沢 淳 (FUJISAWA Jun)",
-			"Dean Jackson"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/SVG"
-		]
-	},
-	"SVG2": {
-		"title": "Scalable Vector Graphics (SVG) 2",
-		"href": "http://www.w3.org/TR/2015/WD-SVG2-20150915/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"Nikos Andronikos",
-			"Rossen Atanassov",
-			"Tavmjong Bah",
-			"Amelia Bellamy-Royds",
-			"Brian Birtles",
-			"Cyril Concolato",
-			"Erik Dahlström",
-			"Chris Lilley",
-			"Cameron McCormack",
-			"Doug Schepers",
-			"Dirk Schulze",
-			"Richard Schwerdtfeger",
-			"Satoru Takagi",
-			"Jonathan Watt"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/PF/"
-		]
-	},
-	"UI-AUTOMATION": {
-		"href": "https://msdn.microsoft.com/en-us/library/ee684009%28v=vs.85%29.aspx",
-		"title": "UI Automation",
-		"publisher": "Microsoft Corporation"
-	},
-	// Custom reference for UIA Express (not available from SpecRef biblio).
-	"UIA-EXPRESS": {
-		"href": "https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898%28v=vs.85%29.aspx",
-		"title": "The IAccessibleEx Interface",
-		"publisher": "Microsoft Corporation"
-	},
 	"WAI-ARIA": {
 		"title": "Accessible Rich Internet Applications (WAI-ARIA) 1.1",
 		"href": "http://www.w3.org/TR/wai-aria-1.1/",
@@ -249,20 +160,6 @@ var biblio = {
 			"Shane McCarron"
 		],
 		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/PF/"
-		]
-	},
-	"WAI-ARIA-10": {
-		"authors": [
-			"James Craig",
-			"Michael Cooper"
-		],
-		"etAl": true,
-		"href": "http://www.w3.org/TR/wai-aria/",
-		"title": "Accessible Rich Internet Applications (WAI-ARIA) 1.0",
-		"status": "REC",
-		"publisher": "W3C",
 		"deliveredBy": [
 			"http://www.w3.org/WAI/PF/"
 		]

--- a/biblio.js
+++ b/biblio.js
@@ -1,104 +1,22 @@
 var biblio = {
 
 	"ACCNAME-AAM": {
-		"title": "Accessible Name and Description: Computation and API Mappings 1.1",
-		"href": "http://www.w3.org/TR/accname-aam-1.1/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors":  [
-			"Joseph Scheuhammer",
-			"Michael Cooper",
-			"Andi Snow-Weaver",
-			"Aaron Leventhal"
-		],
-		"etAl": true,
-		"deliveredBy":  [
-			"http://www.w3.org/WAI/ARIA/"
-		]
+		"aliasOf": "ACCNAME-AAM-1.1",
 	},
 	"ARIA-PRACTICES": {
-		"title": "WAI-ARIA Authoring Practicess 1.1",
-		"href": "http://www.w3.org/TR/wai-aria-practices-1.1/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"Matt King",
-			"James Nurthen",
-			"Michael Cooper",
-			"Michiel Bijl",
-			"Joseph Scheuhammer",
-			"Lisa Pappas",
-			"Richard Schwerdtfeger"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/ARIA/"
-		]
+		"aliasOf": "WAI-ARIA-PRACTICES-1.1",
 	},
 	"CORE-AAM": {
-		"title": "Core Accessibility API Mappings 1.1",
-		"href": "http://www.w3.org/TR/core-aam-1.1/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"Joseph Scheuhammer",
-			"Michael Cooper",
-			"Andi Snow-Weaver",
-			"Aaron Leventhal"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/ARIA/"
-		]
+		"aliasOf": "CORE-AAM-1.1",
 	},
         "DPUB-ARIA": {
-                "title": "Digital Publishing WAI-ARIA Module 1.0",
-                "href": "http://www.w3.org/TR/dpub-aria-1.0/",
-                "status": "WD",
-                "publisher": "W3C",
-                "authors": [
-                        "Matt Garrish",
-                        "Tzviya Siegman",
-                        "Markus Gylling",
-                        "Shane McCarron"
-                ],
-                "etAl": true,
-                "deliveredBy": [
-                        "http://www.w3.org/WAI/ARIA/"
-                ]
+		"aliasOf": "DPUB-ARIA-1.0",
         },
         "GRAPHICS-ARIA": {
-                "title": "WAI-ARIA Graphics",
-                "href": "http://www.w3.org/TR/graphics-aria-1.0/",
-                "status": "WD",
-                "publisher": "W3C",
-                "authors": [
-                        "Amelia Bellamy-Royds",
-                        "Fred Esch",
-                        "Rich Schwerdtfeger",
-                        "Leonie Watson"
-                ],
-                "etAl": true,
-                "deliveredBy": [
-                        "http://www.w3.org/WAI/ARIA/",
-                        "http://www.w3.org/SVG/"
-                ]
+		"aliasOf": "GRAPHICS-ARIA-1.0",
         },
         "GRAPHICS-AAM": {
-                "title": "Graphics Accessibility API Mappings",
-                "href": "http://www.w3.org/TR/graphics-aam-1.0/",
-                "status": "WD",
-                "publisher": "W3C",
-                "authors": [
-                        "Amelia Bellamy-Royds",
-                        "Fred Esch",
-                        "Richard Schwerdtfeger"
-                ],
-                "etAl": true,
-                "deliveredBy": [
-                        "http://www.w3.org/WAI/ARIA/",
-                        "http://www.w3.org/SVG/"
-                ]
+		"aliasOf": "GRAPHICS-AAM-1.0",
         },
 	"EPUB-Content": {
 		"href": "http://www.idpf.org/epub/31/spec/epub-contentdocs.html",
@@ -106,62 +24,15 @@ var biblio = {
 		"publisher": "IDPF"
 	},
 	"HTML-AAM": {
-		"authors": [
-			"Steve Faulkner",
-			"Jason Kiss",
-			"Cynthia Shelly",
-			"Alexander Surkov"
-		],
-		"etAl": true,
-		"href": "http://www.w3.org/TR/html-aam-1.0/",
-		"title": "HTML Accessibility API Mappings 1.0",
-		"status": "WD",
-		"publisher": "W3C",
-		"deliveredBy": [
-			"http://www.w3.org/html",
-			"http://www.w3.org/WAI/PF/"
-		]
+		"aliasOf": "HTML-AAM-1.0",
 	},
 	"SVG-AAM": {
-		"title": "SVG2 Accessibility API Mappings 1.0",
-		"href": "http://www.w3.org/TR/svg-aam-1.0/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"Amelia Bellamy-Royds",
-			"Richard Schwerdtfeger"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/PF/"
-		]
+		"aliasOf": "SVG-AAM-1.0",
 	},
 	"SVG1": {
-		"title": "Scalable Vector Graphics (SVG) 1.0 Specification",
-		"href": "http://www.w3.org/TR/SVG10/",
-		"status": "REC",
-		"publisher": "W3C",
-		"authors": [
-			"John Ferraiolo"
-		],
-		"etAl": true,
-		"deliveredBy": [
-		"http://www.w3.org/SVG"
-		]
+		"aliasOf": "SVG",
 	},
 	"WAI-ARIA": {
-		"title": "Accessible Rich Internet Applications (WAI-ARIA) 1.1",
-		"href": "http://www.w3.org/TR/wai-aria-1.1/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"James Craig",
-			"Michael Cooper",
-			"Shane McCarron"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/PF/"
-		]
+		"aliasOf": "WAI-ARIA-1.1",
 	}
 };


### PR DESCRIPTION
At the present time, Specref contains all but one of our biblio.js references.