### PR TITLE
Don't make issue text all uppercase

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -242,7 +242,6 @@ dl.compact dd {
 }
 .issue {
 	background-color:#0c0;
-	text-transform:uppercase;
 }
 abbr.symbol {
 	border-bottom:none;


### PR DESCRIPTION
The `issue` class in ReSpec is applied to an entire `div` for a titled issue (which is like a note or editor's note, but labelled issue, with a red background, and included in the [Issue Summary](https://github.com/w3c/respec/wiki/issue-summary) index).

Making the entire issue text uppercase is unreadable. The labelling and color formatting should be enough to draw attention to an issue.