### PR TITLE
Update terms to use shorthand refs from biblio.js

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -75,7 +75,7 @@
     </dd>
     <dt><dfn>Expose</dfn></dt>
     <dd>
-      <p>Translated to platform-specific <a class="termref" data-lt="accessibility api">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>. [[CORE-AAM-1.1]]</p>
+      <p>Translated to platform-specific <a class="termref" data-lt="accessibility api">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>. [[CORE-AAM]]</p>
     </dd>
 	<dt><dfn data-lt="graphical document|graphical documents">Graphical Document</dfn></dt>
     <dd>


### PR DESCRIPTION
ReSpec was giving a warning:

> [core-aam-1.1] is referenced in 2 ways: ('CORE-AAM', 'CORE-AAM-1.1'). This causes duplicate entries in the References section.

because the SVG-AAM spec used the shorthand, but the terms file used the longer version. This makes _terms.html_ use the shorthand defined in _biblio.js_.