### PR TITLE
fixes #7

### DIFF
--- a/script/mapping-tables.js
+++ b/script/mapping-tables.js
@@ -48,7 +48,8 @@ function mapTables(respecEvents) {
 			var tableInfo = {};
 			mappingTableInfos.push (tableInfo);
 			//store a reference to the container and hide it
-			tableInfo.tableContainer = $(this).hide();
+			tableInfo.tableContainer = $(this);
+			$(this).hide();
 			//store a reference to the table
 			tableInfo.table = $('table', tableInfo.tableContainer);
 			//create a container div to hold all the details element and insert after table


### PR DESCRIPTION
fixes #7 : fixed typo that caused the reference to `tableContainer` to store the result of `hide()` vs the table container