### PR TITLE
fixed up `dt` not being removed. fixes #8

### DIFF
--- a/script/resolveReferences.js
+++ b/script/resolveReferences.js
@@ -247,12 +247,13 @@ require(["core/pubsubhub"], function(respecEvents) {
             });
     // delete any terms that were not referenced.
             Object.keys(termNames).forEach(function(term) {
-                var $p = $("#"+term) ;
+                var $p = $("#"+term);
                 if ($p) {
-                    var tList = $p.getDfnTitles();
+                    // Delete altered dfn elements and refs
                     $p.parent().next().remove();
-                    $p.remove() ;
-                    tList.forEach(function( item ) {
+                    $p.parent().remove();
+
+                    $p.getDfnTitles().forEach(function( item ) {
                         if (respecConfig.definitionMap[item]) {
                             delete respecConfig.definitionMap[item];
                         }


### PR DESCRIPTION
The previous code was looking for the `dd` directly, and then removing `$p` (the `dfn`), but not also removing the parent of the `dfn`. 

As with the previous PR, let me know how to release rights to the contribution. I require no attribution.