### PR TITLE
build: Remove direct repo ref for aria21 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
-env:
-  global:
-    - GH_REF: github.com/w3c/wcag21.git
-    
+
 git:
   depth: 3
   


### PR DESCRIPTION
Shouldn't hurt, but think it's probably copied from the other setup