### PR TITLE
Fix "Platform Mapping Maintainers" transformation for AAMs

### DIFF
--- a/script/utility.js
+++ b/script/utility.js
@@ -7,7 +7,7 @@ require(["core/pubsubhub"], function(respecEvents) {
     respecEvents.sub('end', function(message) {
     	if (message === 'core/link-to-dfn') {
     		document.querySelectorAll("div.head dt").forEach(function(node){
-    			if (node.textContent == "Authors:") node.textContent = "Platform Mapping Maintainers:";
+                       if (node.textContent.trim() == "Authors:") node.textContent = "Platform Mapping Maintainers:";
     		});
     	}
 	})


### PR DESCRIPTION
The transformation of "Authors" to "Platform Mapping Maintainers" is
done by finding the dt element in the head and matching on the string
"Authors:". Due to some change somewhere (perhaps ReSpec), the "Authors:"
string is now surrounded by whitespace. Trimming the whitespace before
doing the string comparison fixes the problem.

Addresses github issue #25