### PR TITLE
Add name required info to ARIA name from content section

### DIFF
--- a/script/aria.js
+++ b/script/aria.js
@@ -353,7 +353,7 @@ require(["core/pubsubhub"], function( respecEvents ) {
                                 fromAuthor += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
                             } 
                             if (!isAbstract && node.textContent.indexOf("content") !== -1) {
-                                fromContent += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + "</li>";
+                                fromContent += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
                             }
                             if (node.textContent.indexOf("prohibited") !== -1) {
                                 fromProhibited += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";


### PR DESCRIPTION
Resolves https://github.com/w3c/aria/issues/1237 on the ARIA repo by adding the "(name required)" designation to the name from content section.

It's a one-line change, it looks like it was originally just a minor oversight.