### PR TITLE
unicode braille patterns

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -194,6 +194,10 @@
     <dd>
       <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG21]].</p>
     </dd>
+    <dt><dfn data-lt="unicode braille">Unicode Braille Patterns</dfn></dt>
+    <dd>
+      <p>In Unicode, braille is represented in a block called Braille Patterns (U+2800..U+28FF). The block contains all 256 possible patterns of an 8-dot braille cell; this includes the complete 6-dot cell range which is represented by U+2800..U+283F. In all braille systems, the braille pattern dots-0 (U+2800) is used to represent a space or the lack of content; it is also called a blank Braille pattern. See <cite><a href="https://en.wikipedia.org/wiki/Braille_Patterns">Braille Patterns on Wikipedia</a>.</cite></p>
+    </dd>
     <dt><dfn data-lt="user agent|user agents">User Agent</dfn></dt>
     <dd>
       <p>Any software that retrieves, renders and facilitates end user interaction with Web content. This definition may differ from that used in other documents.</p>


### PR DESCRIPTION
Adds term for unicode braille patterns, incl. notes on 6-dot and blank.

Cf. https://github.com/w3c/aria/issues/1232