### PR TITLE
Removes jquery

### DIFF
--- a/script/aria.js
+++ b/script/aria.js
@@ -546,8 +546,9 @@ require(['core/pubsubhub'], function (respecEvents) {
           }
         };
 
-        Object.keys(propList).forEach(function (item) {
+        Object.entries(propList).forEach(function (index) {
           var output = '';
+          var item = index[1];
           var section = document.querySelector('#' + item.name);
           var placeholder = section.querySelector(
             '.state-applicability, .property-applicability'

--- a/script/aria.js
+++ b/script/aria.js
@@ -8,577 +8,761 @@
  */
 
 /* jshint shadow: true, unused: false, laxbreak:true, laxcomma:true, asi: true, eqeqeq: false, strict: implied, jquery: true */
-/* global $, require, updateReferences */
+/* global require, updateReferences */
 
 var roleInfo = {};
 
-require(["core/pubsubhub"], function( respecEvents ) {
+require(['core/pubsubhub'], function (respecEvents) {
+  const button = respecUI.addCommand(
+    'Save roles as JSON',
+    showAriaSave,
+    null,
+    '☁️'
+  );
 
-    const button = respecUI.addCommand("Save roles as JSON", showAriaSave, null, "☁️");
-
-    function showAriaSave() {
-      const json = JSON.stringify(roleInfo, null, '  ') ;
-      const href = "data:text/html;charset=utf-8," + encodeURIComponent(json);
-      const ariaUI = document.createElement("div");
-      ariaUI.classList.add("respec-save-buttons");
-      ariaUI.innerHTML = `
+  function showAriaSave() {
+    const json = JSON.stringify(roleInfo, null, '  ');
+    const href = 'data:text/html;charset=utf-8,' + encodeURIComponent(json);
+    const ariaUI = document.createElement('div');
+    ariaUI.classList.add('respec-save-buttons');
+    ariaUI.innerHTML = `
         <a href="${href}" download="roleInfo.json" class="respec-save-button">Save JSON</a>
-      `
-      respecUI.freshModal("Save Aria roles as JSON", ariaUI, button);
-      ariaUI.querySelector("a").focus();
-    }
+      `;
+    respecUI.freshModal('Save Aria roles as JSON', ariaUI, button);
+    ariaUI.querySelector('a').focus();
+  }
 
+  respecEvents.sub('end', function (msg) {
+    if (msg == 'w3c/conformance') {
+      var propList = {};
+      var globalSP = [];
 
-    respecEvents.sub("end", function( msg ) {
-        if (msg == "w3c/conformance") {
-                var propList = {};
-                var globalSP = [];
+      var skipIndex = 0;
+      var myURL = document.URL;
+      if (myURL.match(/\?fast/)) {
+        skipIndex = 1;
+      }
 
-                var skipIndex = 0;
-                var myURL = document.URL;
-                if (myURL.match(/\?fast/)) {
-                    skipIndex = 1;
+      // process the document before anything else is done
+      // first get the properties
+      Array.prototype.slice
+        .call(document.querySelectorAll('pdef, sdef'))
+        .forEach(function (item) {
+          var type = item.localName === 'pdef' ? 'property' : 'state';
+          var container = item.parentNode;
+          var content = item.innerHTML;
+          var sp = document.createElement('span');
+          var title = item.getAttribute('title');
+          if (!title) {
+            title = content;
+          }
+          sp.className = type + '-name';
+          sp.title = title;
+          sp.innerHTML =
+            '<code>' +
+            content +
+            '</code> <span class="type-indicator">' +
+            type +
+            '</span>';
+          sp.setAttribute('aria-describedby', 'desc-' + title);
+          var dRef = item.nextElementSibling;
+          var desc = dRef.firstElementChild.innerHTML;
+          dRef.id = 'desc-' + title;
+          dRef.setAttribute('role', 'definition');
+          var heading = document.createElement('h4');
+          heading.appendChild(sp);
+          container.replaceChild(heading, item);
+          // add this item to the index
+          propList[title] = {
+            is: type,
+            title: title,
+            name: content,
+            desc: desc,
+            roles: [],
+          };
+          var abstract = container.querySelector('.' + type + '-applicability');
+          if (
+            (abstract.textContent || abstract.innerText) ===
+            'All elements of the base markup'
+          ) {
+            globalSP.push({
+              is: type,
+              title: title,
+              name: content,
+              desc: desc,
+              prohibited: false,
+              deprecated: false,
+            });
+          } else if (
+            (abstract.textContent || abstract.innerText) ===
+            'All elements of the base markup except for some roles or elements that prohibit its use'
+          ) {
+            globalSP.push({
+              is: type,
+              title: title,
+              name: content,
+              desc: desc,
+              prohibited: true,
+              deprecated: false,
+            });
+          } else if (
+            (abstract.textContent || abstract.innerText) ===
+            'Use as a global deprecated in ARIA 1.2'
+          ) {
+            globalSP.push({
+              is: type,
+              title: title,
+              name: content,
+              desc: desc,
+              prohibited: false,
+              deprecated: true,
+            });
+          }
+          // the rdef is gone.  if we are in a div, convert that div to a section
+
+          if (container.nodeName.toLowerCase() == 'div') {
+            // change the enclosing DIV to a section with notoc
+            var sec = document.createElement('section');
+            Array.prototype.slice
+              .call(container.attributes)
+              .forEach(function (attr) {
+                sec.setAttribute(attr.name, attr.value);
+              });
+            sec.classList.add('notoc');
+            var theContents = container.innerHTML;
+            sec.innerHTML = theContents;
+            container.parentNode.replaceChild(sec, container);
+          }
+        });
+
+      if (!skipIndex) {
+        // we have all the properties and states - spit out the
+        // index
+        var propIndex = '';
+        var sortedList = [];
+
+        Object.keys(propList).forEach(function (key) {
+          sortedList.push(key);
+        });
+        sortedList = sortedList.sort();
+
+        for (var i = 0; i < sortedList.length; i++) {
+          var item = propList[sortedList[i]];
+          propIndex +=
+            '<dt><a href="#' +
+            item.title +
+            '" class="' +
+            item.is +
+            '-reference">' +
+            item.name +
+            '</a></dt>\n';
+          propIndex += '<dd>' + item.desc + '</dd>\n';
+        }
+        var node = document.getElementById('index_state_prop');
+        var parentNode = node.parentNode;
+        var l = document.createElement('dl');
+        l.id = 'index_state_prop';
+        l.className = 'compact';
+        l.innerHTML = propIndex;
+        parentNode.replaceChild(l, node);
+
+        var globalSPIndex = '';
+        sortedList = globalSP.sort(function (a, b) {
+          return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        });
+        for (i = 0; i < sortedList.length; i++) {
+          var lItem = sortedList[i];
+          globalSPIndex += '<li>';
+          if (lItem.is === 'state') {
+            globalSPIndex +=
+              '<sref ' +
+              (lItem.prohibited ? 'data-prohibited ' : '') +
+              (lItem.deprecated ? 'data-deprecated ' : '') +
+              'title="' +
+              lItem.name +
+              '">' +
+              lItem.name +
+              ' (state)</sref>';
+          } else {
+            globalSPIndex +=
+              '<pref ' +
+              (lItem.prohibited ? 'data-prohibited ' : '') +
+              (lItem.deprecated ? 'data-deprecated ' : '') +
+              '>' +
+              lItem.name +
+              '</pref>';
+          }
+          if (lItem.prohibited) {
+            globalSPIndex += ' (Except where prohibited)';
+          }
+          if (lItem.deprecated) {
+            globalSPIndex += ' (Global use deprecated in ARIA 1.2)';
+          }
+          globalSPIndex += '</li>\n';
+        }
+        parentNode = document.querySelector('#global_states');
+        if (parentNode) {
+          node = parentNode.querySelector('.placeholder');
+          if (node) {
+            l = document.createElement('ul');
+            l.innerHTML = globalSPIndex;
+            parentNode.replaceChild(l, node);
+          }
+        }
+        // there is only one role that uses the global properties
+        parentNode = document.querySelector(
+          '#roletype td.role-properties span.placeholder'
+        );
+        if (parentNode) {
+          node = parentNode.parentNode;
+          if (
+            (parentNode.textContent || parentNode.innerText) ===
+            'Placeholder for global states and properties'
+          ) {
+            l = document.createElement('ul');
+            l.innerHTML = globalSPIndex;
+            node.replaceChild(l, parentNode);
+          }
+        }
+      }
+
+      // what about roles?
+      //
+      // we need to do a few things here:
+      //   1. expand the rdef elements.
+      //   2. accumulate the roles into a table for the indices
+      //   3. grab the parent role reference so we can build up the tree
+      //   4. grab any local states and properties so we can hand those down to the children
+      //
+
+      var subRoles = [];
+      var roleIndex = '';
+      var fromAuthor = '';
+      var fromContent = '';
+      var fromEncapsulation = '';
+      var fromLegend = '';
+      var fromProhibited = '';
+
+      Array.prototype.slice
+        .call(document.querySelectorAll('rdef'))
+        .forEach(function (item) {
+          var container = item.parentNode;
+          var content = item.innerHTML;
+          var sp = document.createElement('h4');
+          var title = item.getAttribute('title');
+          if (!title) {
+            title = content;
+          }
+
+          var pnID = title;
+          container.id = pnID;
+          sp.className = 'role-name';
+          sp.title = title;
+          // is this a role or an abstract role
+          var type = 'role';
+          var isAbstract = false;
+          var abstract = container.querySelectorAll('.role-abstract');
+          if (abstract.innerText === 'True') {
+            type = 'abstract role';
+            isAbstract = true;
+          }
+          sp.innerHTML =
+            '<code>' +
+            content +
+            '</code> <span class="type-indicator">' +
+            type +
+            '</span>';
+          // sp.id = title;
+          sp.setAttribute('aria-describedby', 'desc-' + title);
+          var dRef = item.nextElementSibling;
+          var desc = dRef.firstElementChild.innerHTML;
+          dRef.id = 'desc-' + title;
+          dRef.setAttribute('role', 'definition');
+          container.replaceChild(sp, item);
+          roleIndex +=
+            '<dt><a href="#' +
+            pnID +
+            '" class="role-reference"><code>' +
+            content +
+            '</code>' +
+            (isAbstract ? ' (abstract role) ' : '') +
+            '</a></dt>\n';
+          roleIndex += '<dd>' + desc + '</dd>\n';
+          // grab info about this role
+          // do we have a parent class?  if so, put us in that parents list
+          var node = Array.prototype.slice.call(
+            container.querySelectorAll('.role-parent rref')
+          );
+          // s will hold the name of the parent role if any
+          var s = null;
+          var parentRoles = [];
+          if (node.length) {
+            node.forEach(function (roleref) {
+              s = roleref.textContent || roleref.innerText;
+
+              if (!subRoles[s]) {
+                subRoles.push(s);
+                subRoles[s] = [];
+              }
+              subRoles[s].push(title);
+              parentRoles.push(s);
+            });
+          }
+          // are there supported states / properties in this role?
+          var attrs = [];
+          Array.prototype.slice
+            .call(
+              container.querySelectorAll(
+                '.role-properties, .role-required-properties, .role-disallowed'
+              )
+            )
+            .forEach(function (node) {
+              if (
+                node &&
+                ((node.textContent && node.textContent.length !== 1) ||
+                  (node.innerText && node.innerText.length !== 1))
+              ) {
+                // looks like we do
+                Array.prototype.slice
+                  .call(node.querySelectorAll('pref,sref'))
+                  .forEach(function (item) {
+                    var name = item.getAttribute('title');
+                    if (!name) {
+                      name = item.textContent || item.innerText;
+                    }
+                    var type = item.localName === 'pref' ? 'property' : 'state';
+                    var req = node.classList.contains(
+                      'role-required-properties'
+                    );
+                    var dis = node.classList.contains('role-disallowed');
+                    var dep = item.hasAttribute('data-deprecated');
+                    attrs.push({
+                      is: type,
+                      name: name,
+                      required: req,
+                      disallowed: dis,
+                      deprecated: dep,
+                    });
+
+                    // remember that the state or property is
+                    // referenced by this role
+                    propList[name].roles.push(title);
+                  });
+              }
+            });
+          roleInfo[title] = {
+            name: title,
+            fragID: pnID,
+            parentRoles: parentRoles,
+            localprops: attrs,
+          };
+
+          // is there a namefrom indication?  If so, add this one to
+          // the list
+          if (!isAbstract) {
+            Array.prototype.slice
+              .call(container.querySelectorAll('.role-namefrom'))
+              .forEach(function (node) {
+                var reqRef = container.querySelector('.role-namerequired');
+                var req = '';
+                if (reqRef && reqRef.innerText === 'True') {
+                  req = ' (name required)';
                 }
 
-
-                // process the document before anything else is done
-                // first get the properties
-                $.each(document.querySelectorAll("pdef, sdef"), function(i, item) {
-                    var type = (item.localName === "pdef" ? "property" : "state");
-                    var container = item.parentNode;
-                    var content = item.innerHTML;
-                    var sp = document.createElement("span");
-                    var title = item.getAttribute("title");
-                    if (!title) {
-                        title = content;
-                    }
-                    sp.className = type + "-name";
-                    sp.title = title;
-                    sp.innerHTML = "<code>" + content + "</code> <span class=\"type-indicator\">" + type + "</span>";
-                    sp.setAttribute("aria-describedby", "desc-" + title);
-                    var dRef = item.nextElementSibling;
-                    var desc = dRef.firstElementChild.innerHTML;
-                    dRef.id = "desc-" + title;
-                    dRef.setAttribute("role", "definition");
-                    var heading = document.createElement("h4");
-                    heading.appendChild(sp);
-                    container.replaceChild(heading, item);
-                    // add this item to the index
-                    propList[title] = { is: type, title: title, name: content, desc: desc, roles: [] };
-                    var abstract = container.querySelector("." + type + "-applicability");
-                    if ((abstract.textContent || abstract.innerText) === "All elements of the base markup") {
-                        globalSP.push({ is: type, title: title, name: content, desc: desc, prohibited: false, deprecated: false });
-                    }
-                    else if ((abstract.textContent || abstract.innerText) === "All elements of the base markup except for some roles or elements that prohibit its use") {
-                        globalSP.push({ is: type, title: title, name: content, desc: desc, prohibited: true, deprecated: false });
-                    } 
-                    else if ((abstract.textContent || abstract.innerText) === "Use as a global deprecated in ARIA 1.2") {
-                        globalSP.push({ is: type, title: title, name: content, desc: desc, prohibited: false, deprecated: true });
-                    }
-                    // the rdef is gone.  if we are in a div, convert that div to a section
-
-                    if (container.nodeName.toLowerCase() == "div") {
-                        // change the enclosing DIV to a section with notoc
-                        var sec = document.createElement("section") ;
-                        $.each(container.attributes, function(i, attr) {
-                            sec.setAttribute(attr.name, attr.value);
-                        });
-                        $(sec).addClass("notoc");
-                        var theContents = container.innerHTML;
-                        sec.innerHTML = theContents;
-                        container.parentNode.replaceChild(sec, container) ;
-                    }
-                });
-                
-                if (!skipIndex) {
-                    // we have all the properties and states - spit out the
-                    // index
-                    var propIndex = "";
-                    var sortedList = [];
-                    $.each(propList, function(i) {
-                        sortedList.push(i);
-                    });
-                    sortedList = sortedList.sort();
-
-                    for (var i = 0; i < sortedList.length; i++) {
-                        var item = propList[sortedList[i]];
-                        propIndex += "<dt><a href=\"#" + item.title + "\" class=\"" + item.is + "-reference\">" + item.name + "</a></dt>\n";
-                        propIndex += "<dd>" + item.desc + "</dd>\n";
-                    }
-                    var node = document.getElementById("index_state_prop");
-                    var parentNode = node.parentNode;
-                    var l = document.createElement("dl");
-                    l.id = "index_state_prop";
-                    l.className = "compact";
-                    l.innerHTML = propIndex;
-                    parentNode.replaceChild(l, node);
-
-                    var globalSPIndex = "";
-                    sortedList = globalSP.sort(function(a,b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0 });
-                    for (i = 0; i < sortedList.length; i++) {
-                        var lItem = sortedList[i];
-                        globalSPIndex += "<li>";
-                        if (lItem.is === "state") {
-                            globalSPIndex += "<sref "+(lItem.prohibited?"data-prohibited ":"")+(lItem.deprecated?"data-deprecated ":"") +"title=\"" + lItem.name + "\">" + lItem.name + " (state)</sref>";
-                        } else {
-                            globalSPIndex += "<pref "+(lItem.prohibited?"data-prohibited ":"")+(lItem.deprecated?"data-deprecated ":"") +">" + lItem.name + "</pref>";
-                        }
-                        if (lItem.prohibited) {
-                            globalSPIndex += " (Except where prohibited)";
-                        }
-                        if (lItem.deprecated) {
-                            globalSPIndex += " (Global use deprecated in ARIA 1.2)"
-                        }
-                        globalSPIndex += "</li>\n";
-                    }
-                    parentNode = document.querySelector("#global_states");
-                    if (parentNode) {
-                        node = parentNode.querySelector(".placeholder");
-                        if (node) {
-                            l = document.createElement("ul");
-                            l.innerHTML = globalSPIndex;
-                            parentNode.replaceChild(l, node);
-                        }
-                    }
-                    // there is only one role that uses the global properties
-                    parentNode = document.querySelector("#roletype td.role-properties span.placeholder");
-                    if (parentNode) {
-                        node = parentNode.parentNode;
-                        if ((parentNode.textContent || parentNode.innerText) === "Placeholder for global states and properties") {
-                            l = document.createElement("ul");
-                            l.innerHTML = globalSPIndex;
-                            node.replaceChild(l, parentNode);
-                        }
-                    }
+                if (node.textContent.indexOf('author') !== -1) {
+                  fromAuthor +=
+                    '<li><a href="#' +
+                    pnID +
+                    '" class="role-reference"><code>' +
+                    content +
+                    '</code></a>' +
+                    req +
+                    '</li>';
                 }
-
-                // what about roles?
-                //
-                // we need to do a few things here:
-                //   1. expand the rdef elements.
-                //   2. accumulate the roles into a table for the indices
-                //   3. grab the parent role reference so we can build up the tree
-                //   4. grab any local states and properties so we can hand those down to the children
-                //
-
-                var subRoles = [];
-                var roleIndex = "";
-                var fromAuthor = "";
-                var fromContent = "";
-                var fromEncapsulation = "";
-                var fromLegend = "";
-                var fromProhibited = "";
-
-                $.each(document.querySelectorAll("rdef"), function(i,item) {
-                    var container = item.parentNode;
-                    var $pn = $(container) ;
-                    var content = item.innerHTML;
-                    var sp = document.createElement("h4");
-                    var title = item.getAttribute("title");
-                    if (!title) {
-                        title = content;
-                    }
-                    var pnID = $pn.makeID("", title) ;
-                    sp.className = "role-name";
-                    sp.title = title;
-                    // is this a role or an abstract role
-                    var type = "role";
-                    var isAbstract = false;
-                    var abstract = container.querySelectorAll(".role-abstract");
-                    if ($(abstract).text() === "True") {
-                        type = "abstract role";
-                        isAbstract = true;
-                    }
-                    sp.innerHTML = "<code>" + content + "</code> <span class=\"type-indicator\">" + type + "</span>";
-                    // sp.id = title;
-                    sp.setAttribute("aria-describedby", "desc-" + title);
-                    var dRef = item.nextElementSibling;
-                    var desc = dRef.firstElementChild.innerHTML;
-                    dRef.id = "desc-" + title;
-                    dRef.setAttribute("role", "definition");
-                    container.replaceChild(sp, item);
-                    roleIndex += "<dt><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code>" + ( isAbstract ? " (abstract role) " : "" ) + "</a></dt>\n";
-                    roleIndex += "<dd>" + desc + "</dd>\n";
-                    // grab info about this role
-                    // do we have a parent class?  if so, put us in that parents list
-                    var node = container.querySelectorAll(".role-parent rref");
-                    // s will hold the name of the parent role if any
-                    var s = null;
-                    var parentRoles = [];
-                    if (node) {
-                        $.each(node, function(foo, roleref) {
-                            s = roleref.textContent || roleref.innerText;
-
-                            if (!subRoles[s]) {
-                                subRoles.push(s);
-                                subRoles[s] = [];
-                            }
-                            subRoles[s].push(title);
-                            parentRoles.push(s);
-                        });
-                    }
-                    // are there supported states / properties in this role?  
-                    var attrs = [];
-                    $.each(container.querySelectorAll(".role-properties, .role-required-properties, .role-disallowed"), function(i, node) {
-                        if (node && ((node.textContent && node.textContent.length !== 1) || (node.innerText && node.innerText.length !== 1))) {
-                            // looks like we do
-                            $.each(node.querySelectorAll("pref,sref"), function(i, item) {
-                                var name = item.getAttribute("title");
-                                if (!name) {
-                                    name = item.textContent || item.innerText;
-                                }
-                                var type = (item.localName === "pref" ? "property" : "state");
-                                var req = $(node).hasClass("role-required-properties");
-                                var dis = $(node).hasClass("role-disallowed");
-                                var dep = item.hasAttribute("data-deprecated");
-                                attrs.push( { is: type, name: name, required: req, disallowed: dis, deprecated: dep } );                                               
-
-                                // remember that the state or property is
-                                // referenced by this role
-                                propList[name].roles.push(title);
-                            });
-                        }
-                    });
-                    roleInfo[title] = { "name": title, "fragID": pnID, "parentRoles": parentRoles, "localprops": attrs };
-                    // is there a namefrom indication?  If so, add this one to
-                    // the list
-                    if (!isAbstract) {
-                        $.each(container.querySelectorAll(".role-namefrom"), function(i, node) {
-                            var reqRef = container.querySelector(".role-namerequired");
-                            var req = "";
-                            if (reqRef && reqRef.innerText === "True") {
-                                req = " (name required)";
-                            }
-
-                            if (node.textContent.indexOf("author") !== -1) {
-                                fromAuthor += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
-                            } 
-                            if (!isAbstract && node.textContent.indexOf("content") !== -1) {
-                                fromContent += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
-                            }
-                            if (node.textContent.indexOf("prohibited") !== -1) {
-                                fromProhibited += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
-                            }
-                            if (node.textContent.indexOf("encapsulation") !== -1) {
-                                fromEncapsulation += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>"; 
-                            }
-                            if (node.textContent.indexOf("legend") !== -1) {
-                                fromLegend += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
-                            }               
-                        });
-                    }
-                    if (container.nodeName.toLowerCase() == "div") {
-                        // change the enclosing DIV to a section with notoc
-                        var sec = document.createElement("section") ;
-                        $.each(container.attributes, function(i, attr) {
-                            sec.setAttribute(attr.name, attr.value);
-                        });
-                        $(sec).addClass("notoc");
-                        var theContents = container.innerHTML;
-                        sec.innerHTML = theContents;
-                        container.parentNode.replaceChild(sec, container) ;
-                    }
-                });
-
-                var getStates = function(role) {
-                    var ref = roleInfo[role];
-                    if (!ref) {
-                        msg.pub("error", "No role definition for " + role);
-                    } else if (ref.allprops) {
-                        return ref.allprops;
-                    } else {
-                        var myList = [];
-                        $.merge(myList, ref.localprops);
-                        $.each(ref.parentRoles, function(i, item) {
-                            var pList = getStates(item);
-                            $.merge(myList, pList);
-                        });
-                        ref.allprops = myList;
-                        return myList;
-                    }
-                };
-                    
-                if (!skipIndex) {
-                    // build up the complete inherited SP lists for each role
-                    // however, if the role already specifies an item, do not include it
-                    $.each(roleInfo, function(i, item) {
-                        var output = "";
-                        var placeholder = document.querySelector("#" + item.fragID + " .role-inherited");
-                        if (placeholder) {
-                            var myList = [];
-                            $.each(item.parentRoles, function(j, role) {
-                                $.merge(myList, getStates(role));
-                            });
-                            /* jshint loopfunc: true */
-                            // strip out any items that we have locally
-                            if (item.localprops.length && myList.length) {
-                                for (var j = myList.length - 1; j >=0; j--) {
-                                    item.localprops.forEach(function(x) {
-                                        if (x.name == myList[j].name) {
-                                            myList.splice(j, 1);
-                                        }
-                                    });
-                                }
-                            }
-
-                            var reducedList = myList.reduce((uniqueList, item) => {
-                                return uniqueList.includes(item) ? uniqueList : [...uniqueList, item]
-                            }, [] )
-
-                            var sortedList = reducedList.sort((a,b) => { 
-                                if (a.name == b.name) {
-                                    // Ensure deprecated false properties occur first
-                                    if (a.deprecated !== b.deprecated) {
-                                        return a.deprecated ? 1 : b.deprecated ? -1 : 0
-                                    }
-                                }
-                                return a.name < b.name ? -1 : a.name > b.name ? 1 : 0 
-                            }, [] )
-
-                            var prev;
-                            for (var k = 0; k < sortedList.length; k++) {
-                                var property = sortedList[k];
-                                var req = "";
-                                var dep = "";
-                                if (property.required) {
-                                    req = " <strong>(required)</strong>";
-                                }
-                                if (property.deprecated) {
-                                    dep = " <strong>(deprecated on this role in ARIA 1.2)</strong>"
-                                }
-                                if (prev != property.name) {
-                                    output += "<li>";
-                                    if (property.is === "state") {
-                                        output += "<sref>" + property.name + "</sref> (state)" + req + dep;
-                                    } else {
-                                        output += "<pref>" + property.name + "</pref>" + req + dep;
-                                    }
-                                    output += "</li>\n";
-                                    prev = property.name;
-                                }
-                            }
-                            if (output !== "") {
-                                output = "<ul>\n" + output + "</ul>\n";
-                                placeholder.innerHTML = output;
-                            }
-                        }
-                    });
-                    
-                    // Update state and property role references
-                    var getAllSubRoles = function(role) {
-                        var ref = subRoles[role];
-                        if (ref && ref.length) {
-                            var myList = [];
-                            $.each(ref, function(j, item) {
-                                if (!myList.item) {
-                                    myList[item] = 1;
-                                    myList.push(item);
-                                    var childList = getAllSubRoles(item);
-                                    $.merge(myList, childList);
-                                }
-                            });
-                            return myList;
-                        } else {
-                            return [];
-                        }
-                    };
-                        
-                    $.each(propList, function(i, item) {
-                        var output = "";
-                        var section = document.querySelector("#" + item.name);
-                        var placeholder = section.querySelector(".state-applicability, .property-applicability");
-                        if (placeholder && ((placeholder.textContent || placeholder.innerText) === "Placeholder") && item.roles.length) {
-                            // update the used in roles list
-                            var sortedList = [];
-                            sortedList = item.roles.sort();
-                            for (var j = 0; j < sortedList.length; j++) {
-                                output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
-                            }
-                            if (output !== "") {
-                                output = "<ul>\n" + output + "</ul>\n";
-                            }
-                            placeholder.innerHTML = output;
-                            // also update any inherited roles
-                            var myList = [];
-                            $.each(item.roles, function(j, role) {
-                                var children = getAllSubRoles(role);
-                                // Some subroles have required properties which are also required by the superclass.
-                                // Example: The checked state of radio, which is also required by superclass checkbox.
-                                // We only want to include these one time, so filter out the subroles.
-                                children = $.grep(children, function(subrole) {
-                                    return $.inArray(subrole, propList[item.name].roles) == -1;
-                                });
-                                $.merge(myList, children);
-                            });
-                            placeholder = section.querySelector(".state-descendants, .property-descendants");
-                            if (placeholder && myList.length) {
-                                sortedList = myList.sort();
-                                output = "";
-                                var last = "";
-                                for (j = 0; j < sortedList.length; j++) {
-                                    var sItem = sortedList[j];
-                                    if (last != sItem) {
-                                        output += "<li><rref>" + sItem + "</rref></li>\n";
-                                        last = sItem;
-                                    }
-                                }
-                                if (output !== "") {
-                                    output = "<ul>\n" + output + "</ul>\n";
-                                }
-                                placeholder.innerHTML = output;
-                            }
-                        }
-                        else if (placeholder && (((placeholder.textContent || placeholder.innerText) ==="Use as a global deprecated in ARIA 1.2")) && item.roles.length)
-                        {
-                            // update the used in roles list
-                            var sortedList = [];
-                            sortedList = item.roles.sort();
-                            //remove roletype from the sorted list
-                            const index = sortedList.indexOf('roletype');
-                            if (index > -1) {
-                                sortedList.splice(index, 1);
-                            }
-
-
-                            for (var j = 0; j < sortedList.length; j++) {
-                                output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
-                            }
-                            if (output !== "") {
-                                output = "<ul>\n" + output + "</ul>\n";
-                            }
-                            placeholder.innerHTML = output;
-                            // also update any inherited roles
-                            var myList = [];
-                            $.each(item.roles, function(j, role) {
-                                var children = getAllSubRoles(role);
-                                // Some subroles have required properties which are also required by the superclass.
-                                // Example: The checked state of radio, which is also required by superclass checkbox.
-                                // We only want to include these one time, so filter out the subroles.
-                                children = $.grep(children, function(subrole) {
-                                    return $.inArray(subrole, propList[item.name].roles) == -1;
-                                });
-                                $.merge(myList, children);
-                            });
-                            placeholder = section.querySelector(".state-descendants, .property-descendants");
-                            if (placeholder && myList.length) {
-                                sortedList = myList.sort();
-                                output = "";
-                                var last = "";
-                                for (j = 0; j < sortedList.length; j++) {
-                                    var sItem = sortedList[j];
-                                    if (last != sItem) {
-                                        output += "<li><rref>" + sItem + "</rref></li>\n";
-                                        last = sItem;
-                                    }
-                                }
-                                if (output !== "") {
-                                    output = "<ul>\n" + output + "</ul>\n";
-                                }
-                                placeholder.innerHTML = output;
-                            }                                
-                        }
-                    });
-                    
-                    // spit out the index
-                    var node = document.getElementById("index_role");
-                    var parentNode = node.parentNode;
-                    var list = document.createElement("dl");
-                    list.id = "index_role";
-                    list.className = "compact";
-                    list.innerHTML = roleIndex;
-                    parentNode.replaceChild(list, node);
-
-                    // and the namefrom lists
-                    node = document.getElementById("index_fromauthor");
-                    if (node) {
-                        parentNode = node.parentNode;
-                        list = document.createElement("ul");
-                        list.id = "index_fromauthor";
-                        list.className = "compact";
-                        list.innerHTML = fromAuthor;
-                        parentNode.replaceChild(list, node);
-                    }
-
-                    node = document.getElementById("index_fromcontent");
-                    if (node) {
-                        parentNode = node.parentNode;
-                        list = document.createElement("ul");
-                        list.id = "index_fromcontent";
-                        list.className = "compact";
-                        list.innerHTML = fromContent;
-                        parentNode.replaceChild(list, node);
-                    }
-
-                    node = document.getElementById("index_fromencapsulation");
-                    if (node) {
-                        parentNode = node.parentNode;
-                        list = document.createElement("ul");
-                        list.id = "index_fromencapsulation";
-                        list.className = "compact";
-                        list.innerHTML = fromEncapsulation;
-                        parentNode.replaceChild(list, node);
-                    }
-
-                    node = document.getElementById("index_fromlegend");
-                    if (node) {
-                        parentNode = node.parentNode;
-                        list = document.createElement("ul");
-                        list.id = "index_fromlegend";
-                        list.className = "compact";
-                        list.innerHTML = fromLegend;
-                        parentNode.replaceChild(list, node);
-                    }
-
-                    node = document.getElementById("index_fromprohibited");
-                    if (node) {
-                        parentNode = node.parentNode;
-                        list = document.createElement("ul");
-                        list.id = "index_fromprohibited";
-                        list.className = "compact";
-                        list.innerHTML = fromProhibited;
-                        parentNode.replaceChild(list, node);
-                    }
-                    // assuming we found some parent roles, update those parents with their children
-                    for (var i=0; i < subRoles.length; i++) {
-                        var item = subRoles[subRoles[i]];
-                        var sortedList = item.sort(function(a,b) { return a < b ? -1 : a > b ? 1 : 0 });
-                        var output = "<ul>\n";
-                        for (var j=0; j < sortedList.length; j++) {
-                            output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
-                        }
-                        output += "</ul>\n";
-                        // put it somewhere
-                        var subRolesContainer = document.querySelector("#" + subRoles[i]);
-                        if (subRolesContainer) {
-                            var subRolesListContainer = subRolesContainer.querySelector(".role-children");
-                            if (subRolesListContainer) {
-                                subRolesListContainer.innerHTML = output;
-                            }
-                        }
-                    }
-
+                if (!isAbstract && node.textContent.indexOf('content') !== -1) {
+                  fromContent +=
+                    '<li><a href="#' +
+                    pnID +
+                    '" class="role-reference"><code>' +
+                    content +
+                    '</code></a>' +
+                    req +
+                    '</li>';
                 }
+                if (node.textContent.indexOf('prohibited') !== -1) {
+                  fromProhibited +=
+                    '<li><a href="#' +
+                    pnID +
+                    '" class="role-reference"><code>' +
+                    content +
+                    '</code></a>' +
+                    req +
+                    '</li>';
+                }
+                if (node.textContent.indexOf('encapsulation') !== -1) {
+                  fromEncapsulation +=
+                    '<li><a href="#' +
+                    pnID +
+                    '" class="role-reference"><code>' +
+                    content +
+                    '</code></a>' +
+                    req +
+                    '</li>';
+                }
+                if (node.textContent.indexOf('legend') !== -1) {
+                  fromLegend +=
+                    '<li><a href="#' +
+                    pnID +
+                    '" class="role-reference"><code>' +
+                    content +
+                    '</code></a>' +
+                    req +
+                    '</li>';
+                }
+              });
+          }
+          if (container.nodeName.toLowerCase() == 'div') {
+            // change the enclosing DIV to a section with notoc
+            var sec = document.createElement('section');
+            Array.prototype.slice
+              .call(container.attributes)
+              .forEach(function (attr) {
+                sec.setAttribute(attr.name, attr.value);
+              });
 
-                // prune out unused rows throughout the document
-                
-                $.each(document.querySelectorAll(".role-abstract, .role-parent, .role-base, .role-related, .role-scope, .role-mustcontain, .role-required-properties, .role-properties, .role-namefrom, .role-namerequired, .role-namerequired-inherited, .role-childpresentational, .role-presentational-inherited, .state-related, .property-related,.role-inherited, .role-children, .property-descendants, .state-descendants, .implicit-values"), function(i, item) {
-                    var content = $(item).text();
-                    if (content.length === 1 || content.length === 0) {
-                        // there is no item - remove the row
-                        item.parentNode.remove();
-                    } else if (content === "Placeholder" 
-                               && !skipIndex 
-                               && (item.className === "role-inherited" 
-                                   || item.className === "role-children"
-                                   || item.className === "property-descendants"
-                                   || item.className === "state-descendants" )) {
-                        item.parentNode.remove();
-                    }
+            sec.classList.add('notoc');
+            var theContents = container.innerHTML;
+            sec.innerHTML = theContents;
+            container.parentNode.replaceChild(sec, container);
+          }
+        });
+
+      var getStates = function (role) {
+        var ref = roleInfo[role];
+        if (!ref) {
+          msg.pub('error', 'No role definition for ' + role);
+        } else if (ref.allprops) {
+          return ref.allprops;
+        } else {
+          var myList = ref.localprops;
+          Array.prototype.slice.call(ref.parentRoles).forEach(function (item) {
+            var pList = getStates(item);
+            myList = myList.concat(pList);
+          });
+          ref.allprops = myList;
+          return myList;
+        }
+      };
+
+      // TODO: test this on a page where `skipIndex` is truthy
+      if (!skipIndex) {
+        // build up the complete inherited SP lists for each role
+        // however, if the role already specifies an item, do not include it
+        Object.keys(roleInfo).forEach(function (item) {
+          var output = '';
+          var placeholder = document.querySelector(
+            '#' + item.fragID + ' .role-inherited'
+          );
+
+          if (placeholder) {
+            var myList = [];
+            item.parentRoles.forEach(function (role) {
+              myList = myList.concat(getStates(role));
+            });
+            /* jshint loopfunc: true */
+            // strip out any items that we have locally
+            if (item.localprops.length && myList.length) {
+              for (var j = myList.length - 1; j >= 0; j--) {
+                item.localprops.forEach(function (x) {
+                  if (x.name == myList[j].name) {
+                    myList.splice(j, 1);
+                  }
                 });
-
-                updateReferences(document);
-
+              }
             }
-    });
 
+            var reducedList = myList.reduce((uniqueList, item) => {
+              return uniqueList.includes(item)
+                ? uniqueList
+                : [...uniqueList, item];
+            }, []);
+
+            var sortedList = reducedList.sort((a, b) => {
+              if (a.name == b.name) {
+                // Ensure deprecated false properties occur first
+                if (a.deprecated !== b.deprecated) {
+                  return a.deprecated ? 1 : b.deprecated ? -1 : 0;
+                }
+              }
+              return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+            }, []);
+
+            var prev;
+            for (var k = 0; k < sortedList.length; k++) {
+              var property = sortedList[k];
+              var req = '';
+              var dep = '';
+              if (property.required) {
+                req = ' <strong>(required)</strong>';
+              }
+              if (property.deprecated) {
+                dep = ' <strong>(deprecated on this role in ARIA 1.2)</strong>';
+              }
+              if (prev != property.name) {
+                output += '<li>';
+                if (property.is === 'state') {
+                  output +=
+                    '<sref>' + property.name + '</sref> (state)' + req + dep;
+                } else {
+                  output += '<pref>' + property.name + '</pref>' + req + dep;
+                }
+                output += '</li>\n';
+                prev = property.name;
+              }
+            }
+            if (output !== '') {
+              output = '<ul>\n' + output + '</ul>\n';
+              placeholder.innerHTML = output;
+            }
+          }
+        });
+
+        // Update state and property role references
+        var getAllSubRoles = function (role) {
+          var ref = subRoles[role];
+          if (ref && ref.length) {
+            var myList = [];
+            ref.forEach(function (item) {
+              if (!myList.item) {
+                myList[item] = 1;
+                myList.push(item);
+                var childList = getAllSubRoles(item);
+                myList = myList.concat(childList);
+              }
+            });
+            return myList;
+          } else {
+            return [];
+          }
+        };
+
+        Object.keys(propList).forEach(function (item) {
+          var output = '';
+          var section = document.querySelector('#' + item.name);
+          var placeholder = section.querySelector(
+            '.state-applicability, .property-applicability'
+          );
+          if (
+            placeholder &&
+            (placeholder.textContent || placeholder.innerText) ===
+              'Placeholder' &&
+            item.roles.length
+          ) {
+            // update the used in roles list
+            var sortedList = [];
+            sortedList = item.roles.sort();
+            for (var j = 0; j < sortedList.length; j++) {
+              output += '<li><rref>' + sortedList[j] + '</rref></li>\n';
+            }
+            if (output !== '') {
+              output = '<ul>\n' + output + '</ul>\n';
+            }
+            placeholder.innerHTML = output;
+            // also update any inherited roles
+            var myList = [];
+            item.roles.forEach(function (role) {
+              var children = getAllSubRoles(role);
+              // Some subroles have required properties which are also required by the superclass.
+              // Example: The checked state of radio, which is also required by superclass checkbox.
+              // We only want to include these one time, so filter out the subroles.
+              children = children.filter(function (subrole) {
+                return subrole.indexOf(propList[item.name].roles) === -1;
+              });
+              myList = myList.concat(children);
+            });
+            placeholder = section.querySelector(
+              '.state-descendants, .property-descendants'
+            );
+            if (placeholder && myList.length) {
+              sortedList = myList.sort();
+              output = '';
+              var last = '';
+              for (j = 0; j < sortedList.length; j++) {
+                var sItem = sortedList[j];
+                if (last != sItem) {
+                  output += '<li><rref>' + sItem + '</rref></li>\n';
+                  last = sItem;
+                }
+              }
+              if (output !== '') {
+                output = '<ul>\n' + output + '</ul>\n';
+              }
+              placeholder.innerHTML = output;
+            }
+          } else if (
+            placeholder &&
+            (placeholder.textContent || placeholder.innerText) ===
+              'Use as a global deprecated in ARIA 1.2' &&
+            item.roles.length
+          ) {
+            // update the used in roles list
+            var sortedList = [];
+            sortedList = item.roles.sort();
+            //remove roletype from the sorted list
+            const index = sortedList.indexOf('roletype');
+            if (index > -1) {
+              sortedList.splice(index, 1);
+            }
+
+            for (var j = 0; j < sortedList.length; j++) {
+              output += '<li><rref>' + sortedList[j] + '</rref></li>\n';
+            }
+            if (output !== '') {
+              output = '<ul>\n' + output + '</ul>\n';
+            }
+            placeholder.innerHTML = output;
+            // also update any inherited roles
+            var myList = [];
+            item.roles.forEach(function (role) {
+              var children = getAllSubRoles(role);
+              // Some subroles have required properties which are also required by the superclass.
+              // Example: The checked state of radio, which is also required by superclass checkbox.
+              // We only want to include these one time, so filter out the subroles.
+              children = children.filter(function (subrole) {
+                return subrole.indexOf(propList[item.name].roles) === -1;
+              });
+              myList = myList.concat(children);
+            });
+            placeholder = section.querySelector(
+              '.state-descendants, .property-descendants'
+            );
+            if (placeholder && myList.length) {
+              sortedList = myList.sort();
+              output = '';
+              var last = '';
+              for (j = 0; j < sortedList.length; j++) {
+                var sItem = sortedList[j];
+                if (last != sItem) {
+                  output += '<li><rref>' + sItem + '</rref></li>\n';
+                  last = sItem;
+                }
+              }
+              if (output !== '') {
+                output = '<ul>\n' + output + '</ul>\n';
+              }
+              placeholder.innerHTML = output;
+            }
+          }
+        });
+
+        // spit out the index
+        var node = document.getElementById('index_role');
+        var parentNode = node.parentNode;
+        var list = document.createElement('dl');
+        list.id = 'index_role';
+        list.className = 'compact';
+        list.innerHTML = roleIndex;
+        parentNode.replaceChild(list, node);
+
+        // and the namefrom lists
+        node = document.getElementById('index_fromauthor');
+        if (node) {
+          parentNode = node.parentNode;
+          list = document.createElement('ul');
+          list.id = 'index_fromauthor';
+          list.className = 'compact';
+          list.innerHTML = fromAuthor;
+          parentNode.replaceChild(list, node);
+        }
+
+        node = document.getElementById('index_fromcontent');
+        if (node) {
+          parentNode = node.parentNode;
+          list = document.createElement('ul');
+          list.id = 'index_fromcontent';
+          list.className = 'compact';
+          list.innerHTML = fromContent;
+          parentNode.replaceChild(list, node);
+        }
+
+        node = document.getElementById('index_fromencapsulation');
+        if (node) {
+          parentNode = node.parentNode;
+          list = document.createElement('ul');
+          list.id = 'index_fromencapsulation';
+          list.className = 'compact';
+          list.innerHTML = fromEncapsulation;
+          parentNode.replaceChild(list, node);
+        }
+
+        node = document.getElementById('index_fromlegend');
+        if (node) {
+          parentNode = node.parentNode;
+          list = document.createElement('ul');
+          list.id = 'index_fromlegend';
+          list.className = 'compact';
+          list.innerHTML = fromLegend;
+          parentNode.replaceChild(list, node);
+        }
+
+        node = document.getElementById('index_fromprohibited');
+        if (node) {
+          parentNode = node.parentNode;
+          list = document.createElement('ul');
+          list.id = 'index_fromprohibited';
+          list.className = 'compact';
+          list.innerHTML = fromProhibited;
+          parentNode.replaceChild(list, node);
+        }
+        // assuming we found some parent roles, update those parents with their children
+        for (var i = 0; i < subRoles.length; i++) {
+          var item = subRoles[subRoles[i]];
+          var sortedList = item.sort(function (a, b) {
+            return a < b ? -1 : a > b ? 1 : 0;
+          });
+          var output = '<ul>\n';
+          for (var j = 0; j < sortedList.length; j++) {
+            output += '<li><rref>' + sortedList[j] + '</rref></li>\n';
+          }
+          output += '</ul>\n';
+          // put it somewhere
+          var subRolesContainer = document.querySelector('#' + subRoles[i]);
+          if (subRolesContainer) {
+            var subRolesListContainer = subRolesContainer.querySelector(
+              '.role-children'
+            );
+            if (subRolesListContainer) {
+              subRolesListContainer.innerHTML = output;
+            }
+          }
+        }
+      }
+
+      // prune out unused rows throughout the document
+      Array.prototype.slice
+        .call(
+          document.querySelectorAll(
+            '.role-abstract, .role-parent, .role-base, .role-related, .role-scope, .role-mustcontain, .role-required-properties, .role-properties, .role-namefrom, .role-namerequired, .role-namerequired-inherited, .role-childpresentational, .role-presentational-inherited, .state-related, .property-related,.role-inherited, .role-children, .property-descendants, .state-descendants, .implicit-values'
+          )
+        )
+        .forEach(function (item) {
+          var content = item.innerText;
+          if (content.length === 1 || content.length === 0) {
+            // there is no item - remove the row
+            item.parentNode.parentNode.removeChild(item.parentNode);
+          } else if (
+            content === 'Placeholder' &&
+            !skipIndex &&
+            (item.className === 'role-inherited' ||
+              item.className === 'role-children' ||
+              item.className === 'property-descendants' ||
+              item.className === 'state-descendants')
+          ) {
+            item.parentNode.remove();
+          }
+        });
+
+      updateReferences(document);
+    }
+  });
 });

--- a/script/ariaChild.js
+++ b/script/ariaChild.js
@@ -4,347 +4,473 @@
 //
 
 /* jshint laxbreak:true, laxcomma:true, asi: true, eqeqeq: false, strict: implied, jquery: true */
-/* global $, require, roleInfo, updateReferences */
-var localRoleInfo = {} ;
+/* global require, roleInfo, updateReferences */
+var localRoleInfo = {};
 
-require(["core/pubsubhub"], function( respecEvents ) {
-    respecEvents.sub("end", function( msg ) {
-        if (msg == "w3c/conformance") {
-                var propList = {};
-                var globalSP = [];
+function makeId(el, pfx, txt) {
+  if (el.hasAttribute('id')) return el.getAttribute('id');
+  var id = '';
+  if (!txt) {
+    if (el.hasAttribute('title')) txt = el.getAttribute('title');
+    else txt = el.textContent;
+  }
+  txt = txt.replace(/^\s+/, '');
+  txt = txt.replace(/\s+$/, '');
+  id += txt;
+  id = id.toLowerCase();
+  if (id.length === 0) id = 'generatedID';
+  id = this.sanitiseID(id);
+  if (pfx) id = pfx + '-' + id;
+  id = this.idThatDoesNotExist(id);
+  el.setAttribute('id', id);
+  return id;
+}
 
-                var skipIndex = 0;
-                var myURL = document.URL;
-                if (myURL.match(/\?fast/)) {
-                    skipIndex = 1;
-                }
+require(['core/pubsubhub'], function (respecEvents) {
+  respecEvents.sub('end', function (msg) {
+    if (msg == 'w3c/conformance') {
+      var propList = {};
+      var globalSP = [];
 
+      var skipIndex = 0;
+      var myURL = document.URL;
+      if (myURL.match(/\?fast/)) {
+        skipIndex = 1;
+      }
 
-                // process the document before anything else is done
-                // first get the properties
-                $.each(document.querySelectorAll("pdef, sdef"), function(i, item) {
-                    var type = (item.localName === "pdef" ? "property" : "state");
-                    var container = item.parentNode;
-                    var content = item.innerHTML;
-                    var sp = document.createElement("span");
-                    var title = item.getAttribute("title");
-                    if (!title) {
-                        title = content;
+      // process the document before anything else is done
+      // first get the properties
+      Array.prototype.slice
+        .call(document.querySelectorAll('pdef, sdef'))
+        .forEach(function (item) {
+          var type = item.localName === 'pdef' ? 'property' : 'state';
+          var container = item.parentNode;
+          var content = item.innerHTML;
+          var sp = document.createElement('span');
+          var title = item.getAttribute('title');
+          if (!title) {
+            title = content;
+          }
+          sp.className = type + '-name';
+          sp.title = title;
+          sp.innerHTML =
+            '<code>' +
+            content +
+            '</code> <span class="type-indicator">(' +
+            type +
+            ')</span>';
+          sp.setAttribute('aria-describedby', 'desc-' + title);
+          var dRef = item.nextElementSibling;
+          var desc = dRef.firstElementChild.innerHTML;
+          dRef.id = 'desc-' + title;
+          dRef.setAttribute('role', 'definition');
+          var heading = document.createElement('h3');
+          heading.appendChild(sp);
+          container.replaceChild(heading, item);
+          // add this item to the index
+          propList[title] = {
+            is: type,
+            title: title,
+            name: content,
+            desc: desc,
+            roles: [],
+          };
+          var abstract = container.querySelector('.' + type + '-applicability');
+          if (
+            (abstract.textContent || abstract.innerText) ===
+            'All elements of the base markup'
+          ) {
+            globalSP.push({
+              is: type,
+              title: title,
+              name: content,
+              desc: desc,
+            });
+          }
+          // the pdef/sdef is gone.  if we are in a div, convert that div to a section
+
+          if (container.nodeName.toLowerCase() == 'div') {
+            // change the enclosing DIV to a section with notoc
+            var sec = document.createElement('section');
+            Array.prototype.slice
+              .call(container.attributes)
+              .forEach(function (attr) {
+                sec.setAttribute(attr.name, attr.value);
+              });
+            sec.classList.add('notoc');
+            var theContents = container.innerHTML;
+            sec.innerHTML = theContents;
+            container.parentNode.replaceChild(sec, container);
+          }
+        });
+
+      // what about roles?
+      //
+      // we need to do a few things here:
+      //   1. expand the rdef elements.
+      //   2. accumulate the roles into a table for the indices
+      //   3. grab the parent role reference so we can build up the tree
+      //   4. grab any local states and properties so we can hand those down to the children
+      //
+
+      var subRoles = [];
+      var roleIndex = '';
+      Array.prototype.slice
+        .call(document.querySelectorAll('rdef'))
+        .forEach(function (item) {
+          var container = item.parentNode;
+          var content = item.innerHTML;
+          var sp = document.createElement('h3');
+          var title = item.getAttribute('title');
+
+          if (!title) {
+            title = content;
+          }
+
+          var pnID = makeID(container, '', title);
+          sp.className = 'role-name';
+          sp.title = title;
+          // is this a role or an abstract role
+          var type = 'role';
+          var abstract = container.querySelectorAll('.role-abstract');
+          if (abstract.innerText === 'True') {
+            type = 'abstract role';
+          }
+
+          sp.innerHTML =
+            '<code>' +
+            content +
+            '</code> <span class="type-indicator">(' +
+            type +
+            ')</span>';
+          // sp.id = title;
+          sp.setAttribute('aria-describedby', 'desc-' + title);
+          var dRef = item.nextElementSibling;
+          var desc = dRef.firstElementChild.innerHTML;
+          dRef.id = 'desc-' + title;
+          dRef.setAttribute('role', 'definition');
+          container.replaceChild(sp, item);
+          roleIndex +=
+            '<dt><a href="#' +
+            pnID +
+            '" class="role-reference">' +
+            content +
+            '</a></dt>\n';
+          roleIndex += '<dd>' + desc + '</dd>\n';
+          // grab info about this role
+          // do we have a parent class?  if so, put us in that parents list
+          var node = container.querySelectorAll('.role-parent rref');
+          // s will hold the name of the parent role if any
+          var s = null;
+          var parentRoles = [];
+          if (node) {
+            Array.prototype.slice.call(node).forEach(function (roleref) {
+              s = roleref.textContent || roleref.innerText;
+
+              if (!subRoles[s]) {
+                subRoles.push(s);
+                subRoles[s] = [];
+              }
+
+              subRoles[s].push(title);
+              parentRoles.push(s);
+            });
+          }
+
+          // are there supported states / properties in this role?
+          var attrs = [];
+          Array.prototype.slice
+            .call(
+              container.querySelectorAll(
+                '.role-properties, .role-required-properties'
+              )
+            )
+            .forEach(function (node) {
+              if (
+                node &&
+                ((node.textContent && node.textContent.length !== 1) ||
+                  (node.innerText && node.innerText.length !== 1))
+              ) {
+                // looks like we do
+                Array.prototype.slice
+                  .call(node.querySelectorAll('pref,sref'))
+                  .forEach(function (item) {
+                    var name = item.getAttribute('title');
+                    if (!name) {
+                      name = item.textContent || item.innerText;
                     }
-                    sp.className = type + "-name";
-                    sp.title = title;
-                    sp.innerHTML = "<code>" + content + "</code> <span class=\"type-indicator\">(" + type + ")</span>";
-                    sp.setAttribute("aria-describedby", "desc-" + title);
-                    var dRef = item.nextElementSibling;
-                    var desc = dRef.firstElementChild.innerHTML;
-                    dRef.id = "desc-" + title;
-                    dRef.setAttribute("role", "definition");
-                    var heading = document.createElement("h3");
-                    heading.appendChild(sp);
-                    container.replaceChild(heading, item);
-                    // add this item to the index
-                    propList[title] = { is: type, title: title, name: content, desc: desc, roles: [] };
-                    var abstract = container.querySelector("." + type + "-applicability");
-                    if ((abstract.textContent || abstract.innerText) === "All elements of the base markup") {
-                        globalSP.push({ is: type, title: title, name: content, desc: desc });
-                    }
-                    // the pdef/sdef is gone.  if we are in a div, convert that div to a section
+                    var type = item.localName === 'pref' ? 'property' : 'state';
+                    var req = node.classList.contains(
+                      'role-required-properties'
+                    );
+                    attrs.push({ is: type, name: name, required: req });
+                    // remember that the state or property is
+                    // referenced by this role
+                    propList[name].roles.push(title);
+                  });
+              }
+            });
 
-                    if (container.nodeName.toLowerCase() == "div") {
-                        // change the enclosing DIV to a section with notoc
-                        var sec = document.createElement("section") ;
-                        $.each(container.attributes, function(i, attr) {
-                            sec.setAttribute(attr.name, attr.value);
-                        });
-                        $(sec).addClass("notoc");
-                        var theContents = container.innerHTML;
-                        sec.innerHTML = theContents;
-                        container.parentNode.replaceChild(sec, container) ;
-                    }
+          localRoleInfo[title] = {
+            name: title,
+            fragID: pnID,
+            parentRoles: parentRoles,
+            localprops: attrs,
+          };
 
+          if (container.nodeName.toLowerCase() == 'div') {
+            // change the enclosing DIV to a section with notoc
+            var sec = document.createElement('section');
+            Array.prototype.slice
+              .call(container.attributes)
+              .forEach(function (attr) {
+                sec.setAttribute(attr.name, attr.value);
+              });
+            sec.classList.add('notoc');
+            var theContents = container.innerHTML;
+            sec.innerHTML = theContents;
+            container.parentNode.replaceChild(sec, container);
+          }
+        });
+
+      var getStates = function (role) {
+        var ref = localRoleInfo[role];
+        if (!ref) {
+          ref = roleInfo[role];
+        }
+        if (!ref) {
+          msg.pub('error', 'No role definition for ' + role);
+        } else if (ref.allprops) {
+          return ref.allprops;
+        } else {
+          var myList = ref.localprops.slice();
+          ref.parentRoles.forEach(function (item) {
+            var pList = getStates(item);
+            pList.forEach(function (item) {
+              myList.push(item);
+            });
+          });
+          ref.allprops = myList;
+          return myList;
+        }
+      };
+
+      if (!skipIndex) {
+        // build up the complete inherited SP lists for each role
+        Object.values(localRoleInfo).forEach(function (item) {
+          var output = '';
+          var placeholder = document.querySelector(
+            '#' + item.fragID + ' .role-inherited'
+          );
+
+          if (placeholder) {
+            var myList = [];
+            item.parentRoles.forEach(function (role) {
+              myList.push(getStates(role));
+            });
+
+            // strip out any items that we have locally
+            /* jshint loopfunc: true */
+            if (item.localprops.length && myList.length) {
+              for (var j = myList.length - 1; j >= 0; j--) {
+                item.localprops.forEach(function (x) {
+                  if (x.name == myList[j].name) {
+                    myList.splice(j, 1);
+                  }
                 });
-                
-                // what about roles?
-                //
-                // we need to do a few things here:
-                //   1. expand the rdef elements.
-                //   2. accumulate the roles into a table for the indices
-                //   3. grab the parent role reference so we can build up the tree
-                //   4. grab any local states and properties so we can hand those down to the children
-                //
-
-                var subRoles = [];
-                var roleIndex = "";
-
-                $.each(document.querySelectorAll("rdef"), function(i,item) {
-                    var container = item.parentNode;
-                    var $pn = $(container) ;
-                    var content = item.innerHTML;
-                    var sp = document.createElement("h3");
-                    var title = item.getAttribute("title");
-                    if (!title) {
-                        title = content;
-                    }
-                    var pnID = $pn.makeID("", title) ;
-                    sp.className = "role-name";
-                    sp.title = title;
-                    // is this a role or an abstract role
-                    var type = "role";
-                    var abstract = container.querySelectorAll(".role-abstract");
-                    if ($(abstract).text() === "True") {
-                        type = "abstract role";
-                    }
-                    sp.innerHTML = "<code>" + content + "</code> <span class=\"type-indicator\">(" + type + ")</span>";
-                    // sp.id = title;
-                    sp.setAttribute("aria-describedby", "desc-" + title);
-                    var dRef = item.nextElementSibling;
-                    var desc = dRef.firstElementChild.innerHTML;
-                    dRef.id = "desc-" + title;
-                    dRef.setAttribute("role", "definition");
-                    container.replaceChild(sp, item);
-                    roleIndex += "<dt><a href=\"#" + pnID + "\" class=\"role-reference\">" + content + "</a></dt>\n";
-                    roleIndex += "<dd>" + desc + "</dd>\n";
-                    // grab info about this role
-                    // do we have a parent class?  if so, put us in that parents list
-                    var node = container.querySelectorAll(".role-parent rref");
-                    // s will hold the name of the parent role if any
-                    var s = null;
-                    var parentRoles = [];
-                    if (node) {
-                        $.each(node, function(foo, roleref) {
-                            s = roleref.textContent || roleref.innerText;
-
-                            if (!subRoles[s]) {
-                                subRoles.push(s);
-                                subRoles[s] = [];
-                            }
-                            subRoles[s].push(title);
-                            parentRoles.push(s);
-                        });
-                    }
-                    // are there supported states / properties in this role?  
-                    var attrs = [];
-                    $.each(container.querySelectorAll(".role-properties, .role-required-properties"), function(i, node) {
-                        if (node && ((node.textContent && node.textContent.length !== 1) || (node.innerText && node.innerText.length !== 1))) {
-                            // looks like we do
-                            $.each(node.querySelectorAll("pref,sref"), function(i, item) {
-                                var name = item.getAttribute("title");
-                                if (!name) {
-                                    name = item.textContent || item.innerText;
-                                }
-                                var type = (item.localName === "pref" ? "property" : "state");
-                                var req = ($(node).hasClass("role-required-properties") ? true : false );
-                                attrs.push( { is: type, name: name, required: req } );
-                                // remember that the state or property is
-                                // referenced by this role
-                                propList[name].roles.push(title);
-                            });
-                        }
-                    });
-                    localRoleInfo[title] = { "name": title, "fragID": pnID, "parentRoles": parentRoles, "localprops": attrs };
-                    if (container.nodeName.toLowerCase() == "div") {
-                        // change the enclosing DIV to a section with notoc
-                        var sec = document.createElement("section") ;
-                        $.each(container.attributes, function(i, attr) {
-                            sec.setAttribute(attr.name, attr.value);
-                        });
-                        $(sec).addClass("notoc");
-                        var theContents = container.innerHTML;
-                        sec.innerHTML = theContents;
-                        container.parentNode.replaceChild(sec, container) ;
-                    }
-                });
-
-                var getStates = function(role) {
-                    var ref = localRoleInfo[role];
-                    if (!ref) {
-                        ref = roleInfo[role];
-                    }
-                    if (!ref) {
-                        msg.pub("error", "No role definition for " + role);
-                    } else if (ref.allprops) {
-                        return ref.allprops;
-                    } else {
-                        var myList = [];
-                        $.merge(myList, ref.localprops);
-                        $.each(ref.parentRoles, function(i, item) {
-                            var pList = getStates(item);
-                            $.merge(myList, pList);
-                        });
-                        ref.allprops = myList;
-                        return myList;
-                    }
-                };
-                    
-                if (!skipIndex) {
-                    // build up the complete inherited SP lists for each role
-                    $.each(localRoleInfo, function(i, item) {
-                        var output = "";
-                        var placeholder = document.querySelector("#" + item.fragID + " .role-inherited");
-                        if (placeholder) {
-                            var myList = [];
-                            $.each(item.parentRoles, function(j, role) {
-                                $.merge(myList, getStates(role));
-                            });
-                            // strip out any items that we have locally
-                            /* jshint loopfunc: true */
-                            if (item.localprops.length && myList.length) {
-                                for (var j = myList.length - 1; j >=0; j--) {
-                                    item.localprops.forEach(function(x) {
-                                        if (x.name == myList[j].name) {
-                                            myList.splice(j, 1);
-                                        }
-                                    });
-                                }
-                            }
-                            var sortedList = [];
-                            sortedList = myList.sort(function(a,b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
-                            var prev;
-                            for (var k = 0; k < sortedList.length; k++) {
-                                var role = sortedList[k];
-                                var req = "";
-                                if (role.required) {
-                                    req = " <strong>(required)</strong>";
-                                }
-                                if (prev != role.name) {
-                                    output += "<li>";
-                                    if (role.is === "state") {
-                                        output += "<sref "+(role.prohibited?"data-prohibited ":"")+(role.deprecated?"data-deprecated ":"") +"title=\"" + role.name + "\">" + role.name + " (state)</sref>" + req;
-                                    } else {
-                                        output += "<pref "+(role.prohibited?"data-prohibited ":"")+(role.deprecated?"data-deprecated ":"") + ">" + role.name + "</pref>" + req;
-                                    }
-                                    if (role.prohibited) {
-                                        output += " (Except where prohibited)";
-                                    }
-                                    if (role.deprecated) {
-                                        output += " (Global use deprecated in ARIA 1.2)"
-                                    }                                    
-                                    output += "</li>\n";
-                                    prev = role.name;
-                                }
-                            }
-                            if (output !== "") {
-                                output = "<ul>\n" + output + "</ul>\n";
-                                placeholder.innerHTML = output;
-                            }
-                        }
-                    });
-                    
-                    // Update state and property role references
-                    var getAllSubRoles = function(role) {
-                        var ref = subRoles[role];
-                        if (ref && ref.length) {
-                            var myList = [];
-                            $.each(ref, function(j, item) {
-                                if (!myList.item) {
-                                    myList[item] = 1;
-                                    myList.push(item);
-                                    var childList = getAllSubRoles(item);
-                                    $.merge(myList, childList);
-                                }
-                            });
-                            return myList;
-                        } else {
-                            return [];
-                        }
-                    };
-                        
-                    $.each(propList, function(i, item) {
-                        var output = "";
-                        var section = document.querySelector("#" + item.name);
-                        var placeholder = section.querySelector(".state-applicability, .property-applicability");
-                        if (placeholder && ((placeholder.textContent || placeholder.innerText) === "Placeholder") && item.roles.length) {
-                            // update the used in roles list
-                            var sortedList = [];
-                            sortedList = item.roles.sort();
-                            for (var j = 0; j < sortedList.length; j++) {
-                                output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
-                            }
-                            if (output !== "") {
-                                output = "<ul>\n" + output + "</ul>\n";
-                            }
-                            placeholder.innerHTML = output;
-                            // also update any inherited roles
-                            var myList = [];
-                            $.each(item.roles, function(j, role) {
-                                var children = getAllSubRoles(role);
-                                // Some subroles have required properties which are also required by the superclass.
-                                // Example: The checked state of radio, which is also required by superclass checkbox.
-                                // We only want to include these one time, so filter out the subroles.
-                                children = $.grep(children, function(subrole) {
-                                    return $.inArray(subrole, propList[item.name].roles) == -1;
-                                });
-                                $.merge(myList, children);
-                            });
-                            placeholder = section.querySelector(".state-descendants, .property-descendants");
-                            if (placeholder && myList.length) {
-                                sortedList = myList.sort();
-                                output = "";
-                                var last = "";
-                                for (var k = 0; k < sortedList.length; k++) {
-                                    var lItem = sortedList[k];
-                                    if (last != lItem) {
-                                        output += "<li><rref>" + lItem + "</rref></li>\n";
-                                        last = lItem;
-                                    }
-                                }
-                                if (output !== "") {
-                                    output = "<ul>\n" + output + "</ul>\n";
-                                }
-                                placeholder.innerHTML = output;
-                            }
-                        }
-                    });
-                    
-                    // spit out the index
-                    var node = document.getElementById("index_role");
-                    var parentNode = node.parentNode;
-                    var list = document.createElement("dl");
-                    list.id = "index_role";
-                    list.className = "compact";
-                    list.innerHTML = roleIndex;
-                    parentNode.replaceChild(list, node);
-
-                    // assuming we found some parent roles, update those parents with their children
-                    for (var i=0; i < subRoles.length; i++) {
-                        var item = subRoles[subRoles[i]];
-                        var sortedList = item.sort(function(a,b) { return a < b ? -1 : a > b ? 1 : 0 });
-                        var output = "<ul>\n";
-                        for (var j=0; j < sortedList.length; j++) {
-                            output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
-                        }
-                        output += "</ul>\n";
-                        // put it somewhere
-                        var subRolesContainer = document.querySelector("#" + subRoles[i]);
-                        if (subRolesContainer) {
-                            var subRolesListContainer = subRolesContainer.querySelector(".role-children");
-                            if (subRolesListContainer) {
-                                subRolesListContainer.innerHTML = output;
-                            }
-                        }
-                    }
-
-                }
-
-                updateReferences(document);
-
-                // prune out unused rows throughout the document
-                
-                $.each(document.querySelectorAll(".role-abstract, .role-parent, .role-base, .role-related, .role-scope, .role-mustcontain, .role-required-properties, .role-properties, .role-namefrom, .role-namerequired, .role-namerequired-inherited, .role-childpresentational, .role-presentational-inherited, .state-related, .property-related,.role-inherited, .role-children, .property-descendants, .state-descendants, .implicit-values"), function(i, item) {
-                    var content = $(item).text();
-                    if (content.length === 1 || content.length === 0) {
-                        // there is no item - remove the row
-                        item.parentNode.remove();
-                    } else if (content === "Placeholder" 
-                               && !skipIndex 
-                               && (item.className === "role-inherited" 
-                                   || item.className === "role-children"
-                                   || item.className === "property-descendants"
-                                   || item.className === "state-descendants" )) {
-                        item.parentNode.remove();
-                    }
-                });
+              }
             }
-    });
-});
+            var sortedList = [];
+            sortedList = myList.sort(function (a, b) {
+              return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+            });
+            var prev;
+            for (var k = 0; k < sortedList.length; k++) {
+              var role = sortedList[k];
+              var req = '';
+              if (role.required) {
+                req = ' <strong>(required)</strong>';
+              }
+              if (prev != role.name) {
+                output += '<li>';
+                if (role.is === 'state') {
+                  output +=
+                    '<sref ' +
+                    (role.prohibited ? 'data-prohibited ' : '') +
+                    (role.deprecated ? 'data-deprecated ' : '') +
+                    'title="' +
+                    role.name +
+                    '">' +
+                    role.name +
+                    ' (state)</sref>' +
+                    req;
+                } else {
+                  output +=
+                    '<pref ' +
+                    (role.prohibited ? 'data-prohibited ' : '') +
+                    (role.deprecated ? 'data-deprecated ' : '') +
+                    '>' +
+                    role.name +
+                    '</pref>' +
+                    req;
+                }
+                if (role.prohibited) {
+                  output += ' (Except where prohibited)';
+                }
+                if (role.deprecated) {
+                  output += ' (Global use deprecated in ARIA 1.2)';
+                }
+                output += '</li>\n';
+                prev = role.name;
+              }
+            }
+            if (output !== '') {
+              output = '<ul>\n' + output + '</ul>\n';
+              placeholder.innerHTML = output;
+            }
+          }
+        });
 
+        // Update state and property role references
+        var getAllSubRoles = function (role) {
+          var ref = subRoles[role];
+          if (ref && ref.length) {
+            var myList = [];
+            ref.forEach(function (item) {
+              if (!myList.item) {
+                myList[item] = 1;
+                myList.push(item);
+                var childList = getAllSubRoles(item);
+                childList.forEach(function (item) {
+                  myList.push(childList);
+                });
+              }
+            });
+            return myList;
+          } else {
+            return [];
+          }
+        };
+
+        Object.values(propList).forEach(function (item) {
+          var output = '';
+          var section = document.querySelector('#' + item.name);
+          var placeholder = section.querySelector(
+            '.state-applicability, .property-applicability'
+          );
+          if (
+            placeholder &&
+            (placeholder.textContent || placeholder.innerText) ===
+              'Placeholder' &&
+            item.roles.length
+          ) {
+            // update the used in roles list
+            var sortedList = [];
+            sortedList = item.roles.sort();
+            for (var j = 0; j < sortedList.length; j++) {
+              output += '<li><rref>' + sortedList[j] + '</rref></li>\n';
+            }
+            if (output !== '') {
+              output = '<ul>\n' + output + '</ul>\n';
+            }
+            placeholder.innerHTML = output;
+            // also update any inherited roles
+            var myList = [];
+            item.roles.forEach(function (role) {
+              getAllSubRoles(role)
+                // Some subroles have required properties which are also required by the superclass.
+                // Example: The checked state of radio, which is also required by superclass checkbox.
+                // We only want to include these one time, so filter out the subroles.
+                .filter(function (subrole) {
+                  return propList[item.name].roles.indexOf(subrole) === -1;
+                })
+                .forEach(function (subrole) {
+                  myList.push(chlidren);
+                });
+            });
+
+            placeholder = section.querySelector(
+              '.state-descendants, .property-descendants'
+            );
+
+            if (placeholder && myList.length) {
+              sortedList = myList.sort();
+              output = '';
+              var last = '';
+              for (var k = 0; k < sortedList.length; k++) {
+                var lItem = sortedList[k];
+                if (last != lItem) {
+                  output += '<li><rref>' + lItem + '</rref></li>\n';
+                  last = lItem;
+                }
+              }
+              if (output !== '') {
+                output = '<ul>\n' + output + '</ul>\n';
+              }
+              placeholder.innerHTML = output;
+            }
+          }
+        });
+
+        // spit out the index
+        var node = document.getElementById('index_role');
+        var parentNode = node.parentNode;
+        var list = document.createElement('dl');
+        list.id = 'index_role';
+        list.className = 'compact';
+        list.innerHTML = roleIndex;
+        parentNode.replaceChild(list, node);
+
+        // assuming we found some parent roles, update those parents with their children
+        for (var i = 0; i < subRoles.length; i++) {
+          var item = subRoles[subRoles[i]];
+          var sortedList = item.sort(function (a, b) {
+            return a < b ? -1 : a > b ? 1 : 0;
+          });
+          var output = '<ul>\n';
+          for (var j = 0; j < sortedList.length; j++) {
+            output += '<li><rref>' + sortedList[j] + '</rref></li>\n';
+          }
+          output += '</ul>\n';
+          // put it somewhere
+          var subRolesContainer = document.querySelector('#' + subRoles[i]);
+          if (subRolesContainer) {
+            var subRolesListContainer = subRolesContainer.querySelector(
+              '.role-children'
+            );
+            if (subRolesListContainer) {
+              subRolesListContainer.innerHTML = output;
+            }
+          }
+        }
+      }
+
+      updateReferences(document);
+
+      // prune out unused rows throughout the document
+
+      Array.prototype.slice.call(
+        document
+          .querySelectorAll(
+            '.role-abstract, .role-parent, .role-base, .role-related, .role-scope, .role-mustcontain, .role-required-properties, .role-properties, .role-namefrom, .role-namerequired, .role-namerequired-inherited, .role-childpresentational, .role-presentational-inherited, .state-related, .property-related,.role-inherited, .role-children, .property-descendants, .state-descendants, .implicit-values'
+          )
+          .forEach(function (item) {
+            var content = item.innerText;
+            if (content.length === 1 || content.length === 0) {
+              // there is no item - remove the row
+              item.parentNode.remove();
+            } else if (
+              content === 'Placeholder' &&
+              !skipIndex &&
+              (item.className === 'role-inherited' ||
+                item.className === 'role-children' ||
+                item.className === 'property-descendants' ||
+                item.className === 'state-descendants')
+            ) {
+              item.parentNode.remove();
+            }
+          })
+      );
+    }
+  });
+});

--- a/script/mapping-tables.js
+++ b/script/mapping-tables.js
@@ -169,31 +169,33 @@ function mapTables(respecEvents) {
         // create content for each <details> element; add row header's content to summary
         var details = document.createElement('details');
         details.className = 'map removeOnSave';
-        details.innerHTML += '<summary id="' + id + '">' + summary;
+
+        var detailsHTML = '<summary id="' + id + '">' + summary;
 
         // if attributes mapping table, append relevant elements to summary
         if (tableInfo.table.classList.contains('attributes')) {
-          details.innerHTML += ' [' + relevantElsSummary + ']';
+          detailsHTML += ' [' + relevantElsSummary + ']';
         }
 
-        details.innerHTML += '</summary><table><caption>' + caption;
+        detailsHTML += '</summary><table><caption>' + caption;
 
         if (tableInfo.table.classList.contains('attributes')) {
-          details.innerHTML += ' [' + relevantElsCaption + ']';
+          detailsHTML += ' [' + relevantElsCaption + ']';
         }
 
-        details.innerHTML += '</caption><tbody>';
+        detailsHTML += '</caption><tbody>';
 
         // add table rows using appropriate header from detailsRowHead array and relevant value from rowCells array
         for (var i = 0, len = rowCells.length; i < len; i++) {
-          details.innerHTML +=
+          detailsHTML +=
             '<tr><th>' +
             rowHeaders[i] +
             '</th><td>' +
             rowCells[i] +
             '</td></tr>';
         }
-        details += '</tbody></table></details>';
+        detailsHTML += '</tbody></table></details>';
+        details.innerHTML = detailsHTML;
 
         // append the <details> element to the detailsContainer div
         tableInfo.detailsContainer.appendChild(details);
@@ -314,7 +316,7 @@ function mapTables(respecEvents) {
         });
         queryAll('span', showHideColButton)
           .filter(function (span) {
-            return !span.classList.conatins('action');
+            return !span.classList.contains('action');
           })
           .forEach(function (span) {
             span.parentNode.removeChild(span);

--- a/script/mapping-tables.js
+++ b/script/mapping-tables.js
@@ -1,265 +1,382 @@
-//check for require() and respec context
-if (typeof require !== "undefined") {
-	/* globals $, require */
-	require(["core/pubsubhub"], function(respecEvents) {
-		mapTables(respecEvents);
-	});
+// check for require() and respec context
+if (typeof require !== 'undefined') {
+  /* globals require */
+  require(['core/pubsubhub'], function (respecEvents) {
+    mapTables(respecEvents);
+  });
 } else {
-	$(document).ready(function() {
-		mapTables(false);
-	});
+  if (document.readyState !== 'loading') {
+    mapTables(false);
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      mapTables(false);
+    });
+  }
+}
+
+function hideElement(element) {
+  element.style.display = 'none';
+}
+
+function showElement(element) {
+  element.style.display = 'block';
+}
+
+function queryAll(selector, context) {
+  context = context || document;
+  return Array.prototype.slice.call(context.querySelectorAll(selector));
+}
+
+function getElementIndex(el) {
+  var i = 0;
+  do {
+    i++;
+  } while ((el = el.previousElementSibling));
+  return i;
 }
 
 function mapTables(respecEvents) {
+  'use strict';
+  var mappingTableInfos = [];
 
-  "use strict";
+  function viewAsSingleTable(mappingTableInfo) {
+    hideElement(mappingTableInfo.detailsContainer);
+    // add <summary> @id to ids array and remove @id from summary
+    queryAll('summary', mappingTableInfo.detailsContainer).forEach(function (
+      summary
+    ) {
+      summary.removeAttribute('id');
+    });
+    showElement(mappingTableInfo.tableContainer);
 
-	var mappingTableInfos = [];
+    // add relevant @id to tr
+    queryAll('tbody tr', mappingTableInfo.tableContainer).forEach(function (
+      tr
+    ) {
+      tr.id = mappingTableInfo.ids[getElementIndex(tr)];
+    });
+  }
 
-	function viewAsSingleTable (mappingTableInfo) {
-		mappingTableInfo.detailsContainer.hide();
-		//add <summary> @id to ids array and remove @id from summary
-		$('summary', mappingTableInfo.detailsContainer).each(function() {
-			$(this).removeAttr('id');
-		});
-		mappingTableInfo.tableContainer.show();
-		//add relevant @id to tr
-		$('tbody tr',mappingTableInfo.tableContainer).each(function() {
-			$(this).attr('id', mappingTableInfo.ids[$(this).index()]);
-		});
-	}
-
-	function viewAsDetails (mappingTableInfo) {
-		mappingTableInfo.tableContainer.hide();
-		//add tr @id to ids array and remove @id from tr
-		$('tbody tr', mappingTableInfo.tableContainer).each(function() {
-			$(this).removeAttr('id');
-		});
-		mappingTableInfo.detailsContainer.show();
-		//add relevant @id to summary
-		$('summary', mappingTableInfo.detailsContainer).each(function() {
-			$(this).attr('id', mappingTableInfo.ids[$('details', mappingTableInfo.detailsContainer).index($(this).parent())]);
-		});
-	}
+  function viewAsDetails(mappingTableInfo) {
+    hideElement(mappingTableInfo.tableContainer);
+    // add tr @id to ids array and remove @id from tr
+    queryAll('tbody tr', mappingTableInfo.tableContainer).forEach(function (
+      tr
+    ) {
+      tr.removeAttribute('id');
+    });
+    showElement(mappingTableInfo.detailsContainer);
+    // add relevant @id to summary
+    queryAll('summary', mappingTableInfo.detailsContainer).forEach(function (
+      summary
+    ) {
+      const details = mappingTableInfo.detailsContainer.querySelector(
+        'details'
+      );
+      summary.id =
+        mappingTableInfo.ids[
+          // TODO: check that this works
+          getElementIndex(details) - getElementIndex(summary.parentNode)
+        ];
+    });
+  }
 
   function mappingTables() {
-		$('.table-container').each(function() {
-			// object to store information about a mapping table.
-			var tableInfo = {};
-			mappingTableInfos.push (tableInfo);
-			//store a reference to the container and hide it
-			tableInfo.tableContainer = $(this).hide();
-			//store a reference to the table
-			tableInfo.table = $('table', tableInfo.tableContainer);
-			//create a container div to hold all the details element and insert after table
-			tableInfo.detailsContainer = $('<div class="details removeOnSave" id="' + tableInfo.table.attr('id') + '-details"></div>');
-		  tableInfo.tableContainer.after(tableInfo.detailsContainer);
-		  // array to store @id attributes for rows and summaries.
-		  tableInfo.ids = [];
+    queryAll('.table-container').forEach(function (container) {
+      // object to store information about a mapping table.
+      var tableInfo = {};
+      mappingTableInfos.push(tableInfo);
 
-			//add switch to view as single table or details/summary
-			var $viewSwitch = $('<button class="switch-view removeOnSave">' + mappingTableLabels.viewByTable + '</button>').on('click', function() {
-				//array to store summary/tr @ids
-				//if current view is details/summary
-				if (tableInfo.detailsContainer.is(':visible')) {
-					viewAsSingleTable (tableInfo);
-					// toggle the $viewSwitch label from view-as-single-table to view-by-X
-					$(this).text(mappingTableLabels.viewByLabels[tableInfo.table.attr('id')]);
-				} else {
-					viewAsDetails (tableInfo);
-					// toggle the $viewSwitch label from view-by-X to view-as-single-table.
-					$(this).text(mappingTableLabels.viewByTable);
-				}
-			});
-			tableInfo.tableContainer.before($viewSwitch);
-			//store the table's column headers in array colHeaders
-			var colHeaders = [];
-			$('thead th', tableInfo.table).each(function() {
-				var colHead = $(this).html();
-				colHeaders.push(colHead);
-			});
-			//remove first column header from array
-			colHeaders.shift();
-			//for each row in the table, create details/summary..
-			$('tbody tr', tableInfo.table).each(function() {
-				//store a reference to the row
-				var $row = $(this),
-				//store a reference to the row header for use in details' summary and table caption
-				$caption = $('th', $row).html(),
-				$summary = $caption.replace(/<a [^>]+>|<\/a>/g,'');
-				//get the tr's @id
-				var id = $row.attr('id');
-				//store the row's @id
-				tableInfo.ids.push(id);
-				//remove the tr's @id since same id will be used in the relevant summary element
-				$row.removeAttr('id');
-				//store the row's cells in array rowCells
-				var rowCells = [];
-				//add row cells to array rowCells for use in the details' table
-				$('td', $row).each(function() {
-					rowCells.push($(this).html());
-				});
-				//clone colHeaders array for use in details table row headers
-				var rowHeaders = colHeaders.slice(0);
-				//if attributes mapping table...
-				if (tableInfo.table.hasClass('attributes')) {
-					//remove second column header from array
-					rowHeaders.shift();
-					//remove and store "HTML elements" cell from rowCells array for use in details' summary and table caption
-					var relevantElsCaption = rowCells.shift(),
-					relevantElsSummary = relevantElsCaption.replace(/<a [^>]+>|<\/a>/g,'');
-				}
-				//create content for each <details> element; add row header's content to summary
-				var details = '<details class="map removeOnSave"><summary id="' + id + '">' + $summary;
-				//if attributes mapping table, append relevant elements to summary
-				if (tableInfo.table.hasClass('attributes')) {
-					details += ' [' + relevantElsSummary + ']';
-				}
-				details += '</summary><table><caption>' + $caption;
-				if (tableInfo.table.hasClass('attributes')) {
-					details += ' [' + relevantElsCaption + ']';
-				}
-				details += '</caption><tbody>';
-				//add table rows using appropriate header from detailsRowHead array and relevant value from rowCells array
-				for(var i=0, len=rowCells.length; i < len; i++) {
-					details += '<tr><th>' + rowHeaders[i] + '</th><td>' + rowCells[i] + '</td></tr>';
-				}
-				details += '</tbody></table></details>';
-				//append the <details> element to the detailsContainer div
-				tableInfo.detailsContainer.append(details);
-			});
-			//add 'expand/collapse all' functionality
-			var $expandAllButton = $('<button class="expand removeOnSave">' + mappingTableLabels.expand + '</button>');
-			var $collapseAllButton = $('<button disabled="disabled" class="collapse removeOnSave">' + mappingTableLabels.collapse + '</button>');
-			tableInfo.detailsContainer.prepend($expandAllButton, $collapseAllButton);
-			var expandCollapseDetails = function($detCont, action) {
-				$detCont.find('details').each(function() {
-					var $details = $(this), 
-					$detailsSummary = $('summary', $details),
-					$detailsNotSummary = $details.children(':not(summary)');
-					if (action == 'collapse') {
-						$details.removeClass('open').prop('open', false);
-						$detailsSummary.attr('aria-expanded', false);
-						$detailsNotSummary.hide();
-					} else {
-						$details.addClass('open').prop('open', true);
-						$detailsSummary.attr('aria-expanded', true);
-						$detailsNotSummary.show();
-					}
-				});
-			};
-			$expandAllButton.on('click', function() {
-				expandCollapseDetails(tableInfo.detailsContainer, 'expand');
-				$(this).attr('disabled', 'disabled');
-				tableInfo.detailsContainer.find('button.collapse').removeAttr('disabled');
-			});
-			$collapseAllButton.on('click', function() {
-				expandCollapseDetails(tableInfo.detailsContainer, 'collapse');
-				$(this).attr('disabled', 'disabled');
-				tableInfo.detailsContainer.find('button.expand').removeAttr('disabled');
-			});
-			//add collapsible table columns functionality
-			var $showHideCols = $('<div class="show-hide-cols removeOnSave"><span>' + mappingTableLabels.showHideCols + '</span></div>');
-			for(var i=0, len=colHeaders.length; i < len; i++) {
-				var toggleLabel = colHeaders[i].replace(/<a [^<]+>|<\/a>/g,'').replace(/<sup>\[Note [0-9]+\]<\/sup>/g, '');
-				var $showHideColButton = $('<button class="hide-col" aria-pressed="false" title="' + mappingTableLabels.hideToolTipText + '"><span class="action">' + mappingTableLabels.hideActionText + '</span> ' + toggleLabel + '</button>').on('click', function() {
-					var index = $(this).index() + 1;
-					if ($(this).attr('class') == 'hide-col') {
-						$('tr>th:nth-child('+index+')', tableInfo.table).hide();
-						$('tr>td:nth-child('+index+')', tableInfo.table).hide();
-						$(this).attr({'class': 'show-col', 'aria-pressed': 'true', 'title': mappingTableLabels.showToolTipText});
-						$('span', $(this)).text(mappingTableLabels.showActionText);
-					} else {
-						$('tr>th:nth-child('+index+')', tableInfo.table).show();
-						$('tr>td:nth-child('+index+')', tableInfo.table).show();
-						$(this).attr({'class': 'hide-col', 'aria-pressed': 'false', 'title': mappingTableLabels.hideToolTipText});
-						$('span', $(this)).text(mappingTableLabels.hideActionText);
-					}
-				});
-				$('span:not(.action)', $showHideColButton).remove();
-				$showHideCols.append($showHideColButton);
-			}
-			tableInfo.tableContainer.prepend($showHideCols);
-		});
-		//call the jquery-details plugin
-		var nativeDetailsSupport = $.fn.details.support;
-		if (!nativeDetailsSupport) {
-			$('html').addClass('no-details');
-		}
-		$('details').details();
-		
-		//Use jquery-details plugin event handlers on details open/close to set state of expand/collapse all buttons
-		$('details').on({
-			'open.details': function() {
-				setExpandCollapseButtons($(this).parent());
-			},
-			'close.details': function() {
-				setExpandCollapseButtons($(this).parent());
-			}
-		});
-		var setExpandCollapseButtons = function($detCont) {
-			var totalDetails = $detCont.find('details').length;
-			var detailsOpen = $detCont.find('details.open, details[open]').length;
-			//if, after the details is opened or closed...
-			if (detailsOpen == totalDetails) {//all details are open, enable collapse all button and disable expand all button
-				$detCont.find('button.collapse').removeAttr('disabled');
-				$detCont.find('button.expand').attr('disabled', 'disabled');
-			} else if (totalDetails > detailsOpen && detailsOpen > 0) {//some but not all details are open, enable collapse all button
-				$detCont.find('button.collapse').removeAttr('disabled');
-				$detCont.find('button.expand').removeAttr('disabled');
-			} else {//no details are open, disable collapse all button and enable expand all button
-				$detCont.find('button.collapse').attr('disabled', 'disabled');
-				$detCont.find('button.expand').removeAttr('disabled');
-			}
-		}
-		//if page URL links to frag id, reset location to frag id once details/summary view is set
-		if(window.location.hash) {
-			var hash = window.location.hash;
-			window.location = hash;
-			//if frag id is for a summary element, expand the parent details element
-			if ($(hash).prop('tagName') == "SUMMARY") {
-				expandReferredDetails(hash);
-			}
-		}
+      // store a reference to the container and hide it
+      tableInfo.tableContainer = container;
+      hideElement(container);
 
-	  // Add a hook to expand referred details element when <a> whose @href is fragid of a <summary> is clicked.
-	  $('a[href^="#"]').each(function() {
-	  	var fragId = $(this).attr('href');
-	  	if ($(fragId).prop('tagName') == "SUMMARY") {
-	  		$(this).on('click', function() {  			
-		  		expandReferredDetails(fragId);
-		  	});
-	  	}
-	  });
+      // store a reference to the table
+      tableInfo.table = container.querySelector('table');
 
-	};
+      // create a container div to hold all the details element and insert after table
+      tableInfo.detailsContainer = document.createElement('div');
+      tableInfo.detailsContainer.className = 'details removeOnSave';
+      tableInfo.id = tableInfo.table.id + '-details';
+      tableInfo.tableContainer.insertAdjacentElement(
+        'afterend',
+        tableInfo.detailsContainer
+      );
 
-	function expandReferredDetails(summaryFragId)	{
-		//if details element is not open, activate click on summary
-		if (!$(summaryFragId).parent().prop('open')) {
-			$(summaryFragId).click();
-		}
-	}
+      // array to store @id attributes for rows and summaries.
+      tableInfo.ids = [];
 
-	if (respecEvents) {
-		// Fix the scroll-to-fragID:
-		// - if running with ReSpec, do not invoke the mapping tables script until
-		//   ReSpec executes its own scroll-to-fragID.
-		// - if running on a published document (no ReSpec), invoke the mapping tables
-		//   script on document ready.
-		respecEvents.sub ("start", function (details) {
-			if (details === "core/location-hash") {
-				mappingTables();
-			}
-		});
-		// Subscribe to ReSpec "save" message to set the mapping tables to
-		// view-as-single-table state.
-		respecEvents.sub ("save", function (details) {
-			mappingTableInfos.forEach (function (item) {
-				viewAsSingleTable (item);
-			});
-		});
-	} else {
-		mappingTables();
-	}
+      // add switch to view as single table or details/summary
+      var viewSwitch = document.createElement('button');
+      viewSwitch.className = 'switch-view removeOnSave';
+      viewSwitch.innerHTML = mappingTableLabels.viewByTable;
+      viewSwitch.addEventListener('click', function () {
+        // array to store summary/tr @ids
+        // if current view is details/summary
+        if (tableInfo.detailsContainer.style.display !== 'none') {
+          viewAsSingleTable(tableInfo);
+          // toggle the viewSwitch label from view-as-single-table to view-by-X
+          viewSwitch.innerHTML =
+            mappingTableLabels.viewByLabels[tableInfo.table.id];
+        } else {
+          viewAsDetails(tableInfo);
+          // toggle the viewSwitch label from view-by-X to view-as-single-table.
+          viewSwitch.innerHTML = mappingTableLabels.viewByTable;
+        }
+      });
+
+      tableInfo.tableContainer.insertAdjacentElement('beforebegin', viewSwitch);
+
+      // store the table's column headers in array colHeaders
+      // TODO: figure out what browsers we have to support and replace this with Array#map if possible
+      var colHeaders = [];
+      queryAll('thead th', tableInfo.table).forEach(function (th) {
+        colHeaders.push(th.innerHTML);
+      });
+
+      // remove first column header from array
+      colHeaders.shift();
+      // for each row in the table, create details/summary..
+      queryAll('tbody tr', tableInfo.table).forEach(function (row) {
+        var caption = row.querySelector('th').innerHTML;
+        var summary = caption.replace(/<a [^>]+>|<\/a>/g, '');
+        // get the tr's @id
+        var id = row.id;
+        // store the row's @id
+        tableInfo.ids.push(id);
+        // remove the tr's @id since same id will be used in the relevant summary element
+        row.removeAttribute('id');
+        // store the row's cells in array rowCells
+        var rowCells = [];
+        // add row cells to array rowCells for use in the details' table
+        queryAll('td', row).forEach(function (cell) {
+          rowCells.push(cell.innerHTML);
+        });
+        // clone colHeaders array for use in details table row headers
+        var rowHeaders = colHeaders.slice(0);
+        // if attributes mapping table...
+        if (tableInfo.table.classList.contains('attributes')) {
+          // remove second column header from array
+          rowHeaders.shift();
+          // remove and store "HTML elements" cell from rowCells array for use in details' summary and table caption
+          var relevantElsCaption = rowCells.shift();
+          var relevantElsSummary = relevantElsCaption.replace(
+            /<a [^>]+>|<\/a>/g,
+            ''
+          );
+        }
+
+        // create content for each <details> element; add row header's content to summary
+        var details = document.createElement('details');
+        details.className = 'map removeOnSave';
+        details.innerHTML += '<summary id="' + id + '">' + summary;
+
+        // if attributes mapping table, append relevant elements to summary
+        if (tableInfo.table.classList.contains('attributes')) {
+          details.innerHTML += ' [' + relevantElsSummary + ']';
+        }
+
+        details.innerHTML += '</summary><table><caption>' + caption;
+
+        if (tableInfo.table.classList.contains('attributes')) {
+          details.innerHTML += ' [' + relevantElsCaption + ']';
+        }
+
+        details.innerHTML += '</caption><tbody>';
+
+        // add table rows using appropriate header from detailsRowHead array and relevant value from rowCells array
+        for (var i = 0, len = rowCells.length; i < len; i++) {
+          details.innerHTML +=
+            '<tr><th>' +
+            rowHeaders[i] +
+            '</th><td>' +
+            rowCells[i] +
+            '</td></tr>';
+        }
+        details += '</tbody></table></details>';
+
+        // append the <details> element to the detailsContainer div
+        tableInfo.detailsContainer.appendChild(details);
+      });
+
+      // add 'expand/collapse all' functionality
+      var expandAllButton = document.createElement('button');
+      expandAllButton.className = 'expand removeOnSave';
+      expandAllButton.innerHTML = mappingTableLabels.expand;
+
+      var collapseAllButton = document.createElement('button');
+      collapseAllButton.disabled = true;
+      collapseAllButton.className = 'collapse removeOnSave';
+      collapseAllButton.innerHTML = mappingTableLabels.collapse;
+
+      tableInfo.detailsContainer.insertBefore(
+        collapseAllButton,
+        tableInfo.detailsContainer.firstChild
+      );
+      tableInfo.detailsContainer.insertBefore(
+        expandAllButton,
+        tableInfo.detailsContainer.firstChild
+      );
+
+      var expandCollapseDetails = function (detCont, action) {
+        queryAll('details', detCont).forEach(function (details) {
+          var detailsSummary = details.querySelector('summary');
+          var detailsNotSummary = Array.prototype.slice
+            .call(details.children)
+            .filter(function (child) {
+              return child !== detailsSummary;
+            });
+
+          if (action == 'collapse') {
+            details.classList.remove('open');
+            details.open = false;
+            detailsSummary.setAttribute('aria-expanded', false);
+            detailsNotSummary.forEach(function (element) {
+              hideElement(element);
+            });
+          } else {
+            details.classList.add('open');
+            details.open = true;
+            detailsSummary.setAttribute('aria-expanded', true);
+            detailsNotSummary.forEach(function (element) {
+              showElement(element);
+            });
+          }
+        });
+      };
+
+      expandAllButton.addEventListener('click', function () {
+        expandCollapseDetails(tableInfo.detailsContainer, 'expand');
+        expandAllButton.disabled = true;
+        tableInfo.detailsContainer
+          .querySelector('button.collapse')
+          .removeAttribute('disabled');
+      });
+
+      collapseAllButton.addEventListener('click', function () {
+        expandCollapseDetails(tableInfo.detailsContainer, 'collapse');
+        collapseAllButton.disabled = true;
+        tableInfo.detailsContainer
+          .querySelector('button.expand')
+          .removeAttribute('disabled');
+      });
+
+      // add collapsible table columns functionality
+      var showHideCols = document.createElement('div');
+      showHideCols.className = 'show-hide-cols removeOnSave';
+      showHideCols.innerHTML =
+        '<span>' + mappingTableLabels.showHideCols + '</span>';
+
+      for (var i = 0, len = colHeaders.length; i < len; i++) {
+        var toggleLabel = colHeaders[i]
+          .replace(/<a [^<]+>|<\/a>/g, '')
+          .replace(/<sup>\[Note [0-9]+\]<\/sup>/g, '');
+
+        var showHideColButton = document.createElement('button');
+        showHideColButton.className = 'hide-col';
+        showHideColButton.setAttribute('aria-pressed', false);
+        showHideColButton.setAttribute(
+          'title',
+          mappingTableLabels.hideToolTipText
+        );
+        showHideColButton.innerHTML =
+          '<span class="action">' +
+          mappingTableLabels.hideActionText +
+          '</span>' +
+          toggleLabel;
+
+        showHideColButton.addEventListener('click', function () {
+          var index = getElementIndex(showHideColButton) + 1;
+          var wasHidden = showHideColButton.className === 'hide-col';
+
+          queryAll(
+            'tr>th:nth-child(' + index + '), tr>td:nth-child(' + index + ')',
+            tableInfo.table
+          ).forEach(function (element) {
+            if (wasHidden) {
+              hideElement(element);
+            } else {
+              showElement(element);
+            }
+          });
+
+          showHideColButton.className = wasHidden ? 'show-col' : 'hide-col';
+          showHideColButton.setAttribute('aria-pressed', wasHidden);
+          showHideColButton.setAttribute(
+            'title',
+            wasHidden
+              ? mappingTableLabels.showToolTipText
+              : mappingTableLabels.hideToolTipText
+          );
+          showHideColButton.querySelector('span').innerText = wasHidden
+            ? mappingTableLabels.showActionText
+            : mappingTableLabels.hideActionText;
+        });
+        queryAll('span', showHideColButton)
+          .filter(function (span) {
+            return !span.classList.conatins('action');
+          })
+          .forEach(function (span) {
+            span.parentNode.removeChild(span);
+          });
+        showHideCols.appendChild(showHideColButton);
+      }
+
+      tableInfo.tableContainer.insertBefore(
+        showHideCols,
+        tableInfo.tableContainer.firstChild
+      );
+    });
+
+    // if page URL links to frag id, reset location to frag id once details/summary view is set
+    if (window.location.hash) {
+      var hash = window.location.hash;
+      window.location = hash;
+      var frag = document.querySelector(hash);
+      // if frag id is for a summary element, expand the parent details element
+      if (frag && frag.tagName === 'SUMMARY') {
+        expandReferredDetails(hash);
+      }
+    }
+
+    // Add a hook to expand referred details element when <a> whose @href is fragid of a <summary> is clicked.
+    queryAll('a[href^="#"]').forEach(function (a) {
+      var fragId = a.getAttribute('href');
+
+      if (fragId.tagName === 'SUMMARY') {
+        a.addEventListener('click', function () {
+          expandReferredDetails(fragId);
+        });
+      }
+    });
+  }
+
+  function expandReferredDetails(summaryFragId) {
+    // if details element is not open, activate click on summary
+    if (!summaryFragId.parentNode.open) {
+      summaryFragId.click();
+    }
+  }
+
+  if (respecEvents) {
+    // Fix the scroll-to-fragID:
+    // - if running with ReSpec, do not invoke the mapping tables script until
+    //   ReSpec executes its own scroll-to-fragID.
+    // - if running on a published document (no ReSpec), invoke the mapping tables
+    //   script on document ready.
+    respecEvents.sub('start', function (details) {
+      if (details === 'core/location-hash') {
+        mappingTables();
+      }
+    });
+    // Subscribe to ReSpec "save" message to set the mapping tables to
+    // view-as-single-table state.
+    respecEvents.sub('save', function (details) {
+      mappingTableInfos.forEach(function (item) {
+        viewAsSingleTable(item);
+      });
+    });
+  } else {
+    mappingTables();
+  }
 }

--- a/script/resolveReferences.js
+++ b/script/resolveReferences.js
@@ -1,223 +1,313 @@
-/* globals respecConfig, $, localRoleInfo, roleInfo, require */
+/* globals respecConfig, localRoleInfo, roleInfo, require */
 /* exported linkCrossReferences, restrictReferences, fixIncludes */
 
+function parents(element, selector) {
+  var elements = [];
+  var parent = element.parentElement;
+
+  while (parent) {
+    if (parent.nodeType !== Node.ELEMENT_NODE) {
+      continue;
+    }
+
+    if (parent.matches(selector)) {
+      elements.push(parent);
+    }
+
+    parent = parent.parentElement;
+  }
+}
+
+function makeId(el, pfx, txt) {
+  if (el.hasAttribute('id')) return el.getAttribute('id');
+  var id = '';
+  if (!txt) {
+    if (el.hasAttribute('title')) txt = el.getAttribute('title');
+    else txt = el.textContent;
+  }
+  txt = txt.replace(/^\s+/, '');
+  txt = txt.replace(/\s+$/, '');
+  id += txt;
+  id = id.toLowerCase();
+  if (id.length === 0) id = 'generatedID';
+  id = this.sanitiseID(id);
+  if (pfx) id = pfx + '-' + id;
+  id = this.idThatDoesNotExist(id);
+  el.setAttribute('id', id);
+  return id;
+}
+
+// NOTE: this was taken from https://github.com/w3c/respec/blob/develop/src/core/utils.js#L474 while removing jQuery
+function getDfnTitles(elem) {
+  const titleSet = new Set();
+  // data-lt-noDefault avoid using the text content of a definition
+  // in the definition list.
+  // ltNodefault is === "data-lt-noDefault"... someone screwed up 😖
+  const normText = 'ltNodefault' in elem.dataset ? '' : norm(elem.textContent);
+  const child = /** @type {HTMLElement | undefined} */ (elem.children[0]);
+  if (elem.dataset.lt) {
+    // prefer @data-lt for the list of title aliases
+    elem.dataset.lt
+      .split('|')
+      .map((item) => norm(item))
+      .forEach((item) => titleSet.add(item));
+  } else if (
+    elem.childNodes.length === 1 &&
+    elem.getElementsByTagName('abbr').length === 1 &&
+    child.title
+  ) {
+    titleSet.add(child.title);
+  } else if (elem.textContent === '""') {
+    titleSet.add('the-empty-string');
+  }
+
+  titleSet.add(normText);
+  titleSet.delete('');
+
+  // We could have done this with @data-lt (as the logic is same), but if
+  // @data-lt was not present, we would end up using @data-local-lt as element's
+  // id (in other words, we prefer textContent over @data-local-lt for dfn id)
+  if (elem.dataset.localLt) {
+    const localLt = elem.dataset.localLt.split('|');
+    localLt.forEach((item) => titleSet.add(norm(item)));
+  }
+
+  const titles = [...titleSet];
+  return titles;
+}
+
 function linkCrossReferences() {
-  "use strict";
+  'use strict';
 
-  var specBaseURL = ( respecConfig.ariaSpecURLs ?
-    respecConfig.ariaSpecURLs[respecConfig.specStatus] : null
-  );
+  var specBaseURL = respecConfig.ariaSpecURLs
+    ? respecConfig.ariaSpecURLs[respecConfig.specStatus]
+    : null;
 
-  var coreMappingURL = (respecConfig.coreMappingURLs ?
-    respecConfig.coreMappingURLs[respecConfig.specStatus] : null
-  );
+  var coreMappingURL = respecConfig.coreMappingURLs
+    ? respecConfig.coreMappingURLs[respecConfig.specStatus]
+    : null;
 
-  var accNameURL = (respecConfig.accNameURLs ?
-    respecConfig.accNameURLs[respecConfig.specStatus] : null
-  );
+  var accNameURL = respecConfig.accNameURLs
+    ? respecConfig.accNameURLs[respecConfig.specStatus]
+    : null;
 
-  var htmlMappingURL = (respecConfig.htmlMappingURLs ?
-    respecConfig.htmlMappingURLs[respecConfig.specStatus] : null
-  );
+  var htmlMappingURL = respecConfig.htmlMappingURLs
+    ? respecConfig.htmlMappingURLs[respecConfig.specStatus]
+    : null;
 
-  var dpubModURL = ( respecConfig.dpubModURLs ?
-    respecConfig.dpubModURLs[respecConfig.specStatus] : null
-  );
+  var dpubModURL = respecConfig.dpubModURLs
+    ? respecConfig.dpubModURLs[respecConfig.specStatus]
+    : null;
 
-  var graphicsModURL = ( respecConfig.graphicsModURLs ?
-    respecConfig.graphicsModURLs[respecConfig.specStatus] : null
-  );
-  var graphicsMappingModURL = ( respecConfig.graphicsMappingModURLs ?
-    respecConfig.graphicsMappingModURLs[respecConfig.specStatus] : null
-  );
-  var practicesURL = ( respecConfig.practicesURLs ?
-    respecConfig.practicesURLs[respecConfig.specStatus] : null
-  );
+  var graphicsModURL = respecConfig.graphicsModURLs
+    ? respecConfig.graphicsModURLs[respecConfig.specStatus]
+    : null;
+  var graphicsMappingModURL = respecConfig.graphicsMappingModURLs
+    ? respecConfig.graphicsMappingModURLs[respecConfig.specStatus]
+    : null;
+  var practicesURL = respecConfig.practicesURLs
+    ? respecConfig.practicesURLs[respecConfig.specStatus]
+    : null;
 
-
-  function setHrefs (selString, baseUrl) {
-    $ (selString).each (
-      function (idx, el) {
-        var href = $ (el).attr ('href');
-        $ (el).attr ('href', baseUrl + href);
-    });
+  function setHrefs(selString, baseUrl) {
+    Array.prototype.slice
+      .call(document.querySelectorAll(selString))
+      .forEach(function (el) {
+        var href = el.getAttribute('href');
+        el.setAttribute('href', baseUrl + href);
+      });
   }
 
   // First the links to the definitions of roles, states, and properties.
   if (!!specBaseURL) {
-    setHrefs ('a.role-reference, a.property-reference, a.state-reference, a.specref', specBaseURL);
-  }
-  else {
-    console.log ("linkCrossReferences():  specBaseURL is not defined.");
+    setHrefs(
+      'a.role-reference, a.property-reference, a.state-reference, a.specref',
+      specBaseURL
+    );
+  } else {
+    console.log('linkCrossReferences():  specBaseURL is not defined.');
   }
 
   // Second, for links to role, state, and property mappings in the core mapping
   // doc.
   if (!!coreMappingURL) {
-    setHrefs ('a.core-mapping', coreMappingURL);
-  }
-  else {
-    console.log ("linkCrossReferences():  Note -- coreMappingURL is not defined.");
+    setHrefs('a.core-mapping', coreMappingURL);
+  } else {
+    console.log(
+      'linkCrossReferences():  Note -- coreMappingURL is not defined.'
+    );
   }
 
   // Third, for links into the accname document.
   if (!!accNameURL) {
-    setHrefs ('a.accname', accNameURL);
-  }
-  else {
-    console.log ("linkCrossReferences():  Note -- accNameURL is not defined.");
+    setHrefs('a.accname', accNameURL);
+  } else {
+    console.log('linkCrossReferences():  Note -- accNameURL is not defined.');
   }
   // Fourth, for links to role, state, and property mappings in the html mapping
   // doc.
   if (!!htmlMappingURL) {
-    setHrefs ('a.html-mapping', htmlMappingURL);
-  }
-  else {
-    console.log ("linkCrossReferences():  Note -- htmlMappingURL is not defined.");
+    setHrefs('a.html-mapping', htmlMappingURL);
+  } else {
+    console.log(
+      'linkCrossReferences():  Note -- htmlMappingURL is not defined.'
+    );
   }
   // Links to the DPub WAI-ARIA Module.
   if (!!dpubModURL) {
-    setHrefs ('a.dpub-role-reference, a.dpub-property-reference, a.dpub-state-reference, a.dpub', dpubModURL);
+    setHrefs(
+      'a.dpub-role-reference, a.dpub-property-reference, a.dpub-state-reference, a.dpub',
+      dpubModURL
+    );
+  } else {
+    console.log('linkCrossReferences():  dpubModURL is not defined.');
   }
-  else {
-    console.log ("linkCrossReferences():  dpubModURL is not defined.");
-  }
-// Links to the Graphics WAI-ARIA Module.
+  // Links to the Graphics WAI-ARIA Module.
   if (!!graphicsModURL) {
-    setHrefs ('a.graphics-role-reference, a.graphics-property-reference, a.graphics-state-reference, a.graphics', graphicsModURL);
+    setHrefs(
+      'a.graphics-role-reference, a.graphics-property-reference, a.graphics-state-reference, a.graphics',
+      graphicsModURL
+    );
+  } else {
+    console.log('linkCrossReferences():  graphicsModURL is not defined.');
   }
-  else {
-    console.log ("linkCrossReferences():  graphicsModURL is not defined.");
-  }
-// Links to the Graphics Mapping WAI-ARIA Module.
+  // Links to the Graphics Mapping WAI-ARIA Module.
   if (!!graphicsMappingModURL) {
-    setHrefs ('a.graphics-role-mapping, a.graphics-property-mapping, a.graphics-state-mapping, a.graphics-mapping', graphicsMappingModURL);
+    setHrefs(
+      'a.graphics-role-mapping, a.graphics-property-mapping, a.graphics-state-mapping, a.graphics-mapping',
+      graphicsMappingModURL
+    );
+  } else {
+    console.log(
+      'linkCrossReferences():  graphicsMappingModURL is not defined.'
+    );
   }
-  else {
-    console.log ("linkCrossReferences():  graphicsMappingModURL is not defined.");
-  }
-// Links to the Authoring Practices.
+  // Links to the Authoring Practices.
   if (!!practicesURL) {
-    setHrefs ('a.practices', practicesURL);
+    setHrefs('a.practices', practicesURL);
+  } else {
+    console.log('linkCrossReferences():  practicesURL is not defined.');
   }
-  else {
-    console.log ("linkCrossReferences():  practicesURL is not defined.");
-  }
-
-
-
 }
 
 function updateReferences(base) {
-    // update references to properties
-    //
-    // New logic:
-    //     1. for each item, find it's nearest 'section' ancestor (or nearest div
-    //     with a class of role, property, or state)
-    //     2. if we have not already seen this item in this section, it is a link using 'a'
-    //     3. otherwise, it is just a styled reference to the item  using 'code'
+  // update references to properties
+  //
+  // New logic:
+  //     1. for each item, find it's nearest 'section' ancestor (or nearest div
+  //     with a class of role, property, or state)
+  //     2. if we have not already seen this item in this section, it is a link using 'a'
+  //     3. otherwise, it is just a styled reference to the item  using 'code'
 
-    "use strict";
+  'use strict';
 
-    var baseURL = respecConfig.ariaSpecURLs[respecConfig.specStatus];
+  var baseURL = respecConfig.ariaSpecURLs[respecConfig.specStatus];
 
-    var sectionMap = {} ;
-
-    $.each(base.querySelectorAll("pref, sref, rref"), function(i, item) {
-        var $item = $(item) ;
-
-        // what are we referencing?
-        var content = $item.text();
-        var usedTitle = false;
-        var ref = $item.attr("title");
+  var sectionMap = {};
+  Array.prototype.slice
+    .call(base.querySelectorAll('pref, sref, rref'))
+    .forEach(function (item) {
+      // what are we referencing?
+      var content = item.innerText;
+      var usedTitle = false;
+      var ref = item.getAttribute('title');
+      if (!ref) {
+        ref = item.getAttribute('data-lt');
         if (!ref) {
-            ref = $item.attr("data-lt");
-            if (!ref) {
-                ref = content;
-            } else {
-                usedTitle = true;
-            }
+          ref = content;
         } else {
-            usedTitle = true;
+          usedTitle = true;
         }
+      } else {
+        usedTitle = true;
+      }
 
-        // what sort of reference are we?
-        var theClass = ($item.is("pref") ? "property-reference" : ($item.is("sref") ? "state-reference" : "role-reference"));
+      var isPreref = item.tagName.toLowerCase() === 'pref';
+      var isSref = item.tagName.toLowerCase() === 'sref';
+      // what sort of reference are we?
+      var theClass = isPreref
+        ? 'property-reference'
+        : isSref
+        ? 'state-reference'
+        : 'role-reference';
 
-        // property and state references are assumed to be in the parent document
-        // a role reference might be local or might be elsewhere
-        var URL = $item.is("pref, sref") ? baseURL+"#" : "#";
+      // property and state references are assumed to be in the parent document
+      // a role reference might be local or might be elsewhere
+      var URL = isPreref || isSref ? baseURL + '#' : '#';
 
-        // assume we are making a link
-        var theElement = "a";
+      // assume we are making a link
+      var theElement = 'a';
 
-        // pSec is the nearest parent section element
-        var $pSec = $item.parents("section,div.role,div.state,div.property").first();
-        var pID = $pSec.attr("id");
-        if (pID) {
-            if (sectionMap[pID]) {
-                if (sectionMap[pID][ref]) {
-                    // only change the element if we not in a table or a dl
-                    if ($item.parents("table,dl").length === 0) {
-                        if (usedTitle) {
-                            theElement = "span";
-                        } else {
-                            theElement = "code";
-                        }
-                    }
-                } else {
-                    sectionMap[pID][ref] = 1;
-                }
-            } else {
-                sectionMap[pID] = {} ;
-                sectionMap[pID][ref] = 1;
+      // pSec is the nearest parent section element
+      var pSec = parents(item, 'section, div.role, div.state, div.property')[0];
+      var pID = pSec.id;
+
+      if (pID) {
+        if (sectionMap[pID]) {
+          if (sectionMap[pID][ref]) {
+            // only change the element if we not in a table or a dl
+            if (parents(item, 'table dl').length === 0) {
+              if (usedTitle) {
+                theElement = 'span';
+              } else {
+                theElement = 'code';
+              }
             }
+          } else {
+            sectionMap[pID][ref] = 1;
+          }
+        } else {
+          sectionMap[pID] = {};
+          sectionMap[pID][ref] = 1;
         }
+      }
 
-        if (theElement === "a" && $item.is('rref') ) {
-            if (typeof localRoleInfo !== 'undefined' && localRoleInfo[ref]) {
-                ref = localRoleInfo[ref].fragID;
-            } else if (baseURL && roleInfo[ref]) {
-                ref = roleInfo[ref].fragID;
-                URL = baseURL + "#";
-            } else {
-                // no roleInfo structure.  Make an assumption
-                URL = baseURL + "#";
-            }
+      if (theElement === 'a' && item.tagName.toLowerCase() === 'rref') {
+        if (typeof localRoleInfo !== 'undefined' && localRoleInfo[ref]) {
+          ref = localRoleInfo[ref].fragID;
+        } else if (baseURL && roleInfo[ref]) {
+          ref = roleInfo[ref].fragID;
+          URL = baseURL + '#';
+        } else {
+          // no roleInfo structure.  Make an assumption
+          URL = baseURL + '#';
         }
-        var sp = document.createElement(theElement);
-        if (theElement === "a") {
-            sp.href = URL + ref;
-            sp.className = theClass;
-            content = "<code>" + content + "</code>";
-        }
-        sp.innerHTML=content;
-        $item.replaceWith(sp);
+      }
+      var sp = document.createElement(theElement);
+      if (theElement === 'a') {
+        sp.href = URL + ref;
+        sp.className = theClass;
+        content = '<code>' + content + '</code>';
+      }
+      sp.innerHTML = content;
+      item.parentElement.replaceChild(sp, item);
     });
 }
 
 // We should be able to remove terms that are not actually
 // referenced from the common definitions. This array is
 // indexed with the element ids of the dfn tags to be pruned.
-var termNames = [] ;
+var termNames = [];
 
 function restrictReferences(utils, content) {
-    "use strict";
-    var base = document.createElement("div");
-    base.innerHTML = content;
-    updateReferences(base);
+  'use strict';
+  var base = document.createElement('div');
+  base.innerHTML = content;
+  updateReferences(base);
 
-    // strategy: Traverse the content finding all of the terms defined
-    $.each(base.querySelectorAll("dfn"), function(i, item) {
-        var $t = $(item) ;
-        var titles = $t.getDfnTitles();
-        var n = $t.makeID("dfn", titles[0]);
-        if (n) {
-            termNames[n] = $t.parent() ;
-        }
+  // strategy: Traverse the content finding all of the terms defined
+  Array.prototype.slice
+    .call(base.querySelectorAll('dfn'))
+    .forEach(function (item) {
+      var titles = getDfnTitles(item);
+      var n = makeId(item, 'dfn', titles[0]);
+
+      if (n) {
+        termNames[n] = item.parentNode;
+      }
     });
 
-    return (base.innerHTML);
+  return base.innerHTML;
 }
 
 // add a handler to come in after all the definitions are resolved
@@ -228,58 +318,70 @@ function restrictReferences(utils, content) {
 // consider it an internal reference and ignore it -- assuming
 // it is not part of another included term.
 
-require(["core/pubsubhub"], function(respecEvents) {
-    "use strict";
-    respecEvents.sub('end', function(message) {
-        if (message === 'core/link-to-dfn') {
-            // all definitions are linked
-            $("a.internalDFN").each(function () {
-                var $item = $(this) ;
-                var t = $item.attr('href');
-                if ( $item.closest('dl.termlist').length ) {
-                    if ( $(t).closest('dl.termlist').length ) {
-                        // Figure out the id of the glossary term which holds this
-                        // internal reference and see if it will be pruned (i.e.
-                        // is in the termNames array). If it is, we can ignore
-                        // this particular internal reference.
-                        var dfn = $item.closest('dd').prev().find('dfn');
-                        var parentTermId = dfn.makeID('dfn', dfn.getDfnTitles[0]);
-                        if (termNames[parentTermId])
-                            return;
-                    }
-                }
-                var r = t.replace(/^#/,"") ;
-                if (termNames[r]) {
-                    delete termNames[r] ;
-                }
-            });
-    // delete any terms that were not referenced.
-            if (!respecConfig.definitionMap) return;
-            Object.keys(termNames).forEach(function(term) {
-                var $p = $("#"+term);
-                if ($p) {
-                    // Delete altered dfn elements and refs
-                    $p.parent().next().remove();
-                    $p.parent().remove();
+require(['core/pubsubhub'], function (respecEvents) {
+  'use strict';
 
-                    $p.getDfnTitles().forEach(function( item ) {
-                        if (respecConfig.definitionMap[item]) {
-                            delete respecConfig.definitionMap[item];
-                        }
-                    });
-                }
-            });
+  respecEvents.sub('end', function (message) {
+    if (message === 'core/link-to-dfn') {
+      // all definitions are linked
+      Array.prototype.slice
+        .call(document.querySelectorAll('a.internalDFN'))
+        .forEach(function (item) {
+          var t = item.getAttribute('href');
+          if (item.closest('dl.termlist')) {
+            if (
+              document.querySelector(t) &&
+              document.querySelector(t).closest('dl.termlist')
+            ) {
+              // Figure out the id of the glossary term which holds this
+              // internal reference and see if it will be pruned (i.e.
+              // is in the termNames array). If it is, we can ignore
+              // this particular internal reference.
+              var dd = item.closest('dd');
+              var dfn =
+                dd &&
+                dd.previousElementSibling &&
+                dd.previousElementSibling.querySelector('dfn');
+              var parentTermId = makeID(dfn, 'dfn', getDfnTitles(dfn)[0]);
+              if (termNames[parentTermId]) return;
+            }
+          }
+
+          var r = t.replace(/^#/, '');
+          if (termNames[r]) {
+            delete termNames[r];
+          }
+        });
+      // delete any terms that were not referenced.
+      if (!respecConfig.definitionMap) return;
+      Object.keys(termNames).forEach(function (term) {
+        var p = document.getElementById(term);
+
+        if (p) {
+          // Delete altered dfn elements and refs
+          p.parentNode.nextElementSibling.parentNode.removeChild(
+            nextElementSibling
+          );
+          p.parentNode.parentNode.removeChild(p.parentNode);
+
+          getDfnTitles(p).forEach(function (item) {
+            if (respecConfig.definitionMap[item]) {
+              delete respecConfig.definitionMap[item];
+            }
+          });
         }
-    });
+      });
+    }
+  });
 });
 
 // included files are brought in after proProc.  Create a DOM tree
 // of content then call the updateReferences method above on it.  Return
 // the transformed content
 function fixIncludes(utils, content) {
-    "use strict";
-    var base = document.createElement("div");
-    base.innerHTML = content;
-    updateReferences(base);
-    return (base.innerHTML);
+  'use strict';
+  var base = document.createElement('div');
+  base.innerHTML = content;
+  updateReferences(base);
+  return base.innerHTML;
 }

--- a/script/roleInfo.js
+++ b/script/roleInfo.js
@@ -15,6 +15,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -38,6 +52,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -237,6 +258,251 @@ var roleInfo = {
 		  "disallowed": false,
 		  "deprecated": false
 		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"associationlist": {
+	  "name": "associationlist",
+	  "fragID": "associationlist",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"associationlistitemkey": {
+	  "name": "associationlistitemkey",
+	  "fragID": "associationlistitemkey",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"associationlistitemvalue": {
+	  "name": "associationlistitemvalue",
+	  "fragID": "associationlistitemvalue",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
 	  ]
 	},
 	"banner": {
@@ -331,6 +597,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-colindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-colspan",
 		  "required": false,
 		  "disallowed": false,
@@ -339,6 +612,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-rowindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowindextext",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -361,6 +641,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-colindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-colspan",
 		  "required": false,
 		  "disallowed": false,
@@ -375,6 +662,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-rowindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-rowspan",
 		  "required": false,
 		  "disallowed": false,
@@ -383,6 +677,20 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -411,6 +719,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -637,6 +952,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -660,6 +989,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -827,13 +1163,6 @@ var roleInfo = {
 	  ],
 	  "localprops": [
 		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
 		  "is": "state",
 		  "name": "aria-expanded",
 		  "required": true,
@@ -850,6 +1179,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-autocomplete",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -907,6 +1243,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -930,6 +1280,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -1048,6 +1405,36 @@ var roleInfo = {
 		}
 	  ]
 	},
+	"comment": {
+	  "name": "comment",
+	  "fragID": "comment",
+	  "parentRoles": [
+		"article"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
 	"complementary": {
 	  "name": "complementary",
 	  "fragID": "complementary",
@@ -1101,6 +1488,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -1124,6 +1525,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -1256,7 +1664,22 @@ var roleInfo = {
 	  "parentRoles": [
 		"section"
 	  ],
-	  "localprops": []
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
 	},
 	"deletion": {
 	  "name": "deletion",
@@ -1304,6 +1727,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -1327,6 +1764,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -1469,6 +1913,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -1492,6 +1950,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -1666,6 +2131,13 @@ var roleInfo = {
 	  "localprops": [
 		{
 		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-label",
 		  "required": false,
 		  "disallowed": true,
@@ -1747,6 +2219,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -1770,6 +2256,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -1908,6 +2401,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -1931,6 +2438,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2180,6 +2694,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-colindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-colspan",
 		  "required": false,
 		  "disallowed": false,
@@ -2194,6 +2715,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-rowindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-rowspan",
 		  "required": false,
 		  "disallowed": false,
@@ -2202,6 +2730,20 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2230,6 +2772,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2354,6 +2903,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -2377,6 +2940,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2540,6 +3110,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -2563,6 +3147,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2736,6 +3327,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -2759,6 +3364,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2900,6 +3512,14 @@ var roleInfo = {
 		}
 	  ]
 	},
+	"label": {
+	  "name": "label",
+	  "fragID": "label",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
 	"landmark": {
 	  "name": "landmark",
 	  "fragID": "landmark",
@@ -2911,6 +3531,20 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -2939,6 +3573,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -3057,6 +3698,14 @@ var roleInfo = {
 		}
 	  ]
 	},
+	"legend": {
+	  "name": "legend",
+	  "fragID": "legend",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
 	"link": {
 	  "name": "link",
 	  "fragID": "link",
@@ -3103,6 +3752,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -3126,6 +3789,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -3354,6 +4024,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -3377,6 +4061,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -3511,6 +4202,29 @@ var roleInfo = {
 	  ],
 	  "localprops": []
 	},
+	"mark": {
+	  "name": "mark",
+	  "fragID": "mark",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
 	"marquee": {
 	  "name": "marquee",
 	  "fragID": "marquee",
@@ -3580,6 +4294,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -3603,6 +4331,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -3741,6 +4476,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -3764,6 +4513,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -3977,6 +4733,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -4000,6 +4770,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4132,206 +4909,23 @@ var roleInfo = {
 		  "disallowed": false,
 		  "deprecated": false
 		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
 	  ]
 	},
 	"menuitemradio": {
 	  "name": "menuitemradio",
 	  "fragID": "menuitemradio",
 	  "parentRoles": [
-		"menuitemcheckbox"
+		"menuitem"
 	  ],
-	  "localprops": []
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
 	},
 	"navigation": {
 	  "name": "navigation",
@@ -4364,13 +4958,6 @@ var roleInfo = {
 	  "localprops": [
 		{
 		  "is": "state",
-		  "name": "aria-selected",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
 		  "name": "aria-checked",
 		  "required": false,
 		  "disallowed": false,
@@ -4379,6 +4966,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4394,13 +4988,6 @@ var roleInfo = {
 	  "allprops": [
 		{
 		  "is": "state",
-		  "name": "aria-selected",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
 		  "name": "aria-checked",
 		  "required": false,
 		  "disallowed": false,
@@ -4409,6 +4996,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4430,6 +5024,20 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4458,6 +5066,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4771,6 +5386,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -4794,6 +5423,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -4933,6 +5569,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -4956,6 +5606,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -5082,6 +5739,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -5105,6 +5776,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -5268,6 +5946,13 @@ var roleInfo = {
 		},
 		{
 		  "is": "property",
+		  "name": "aria-rowindextext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
 		  "name": "aria-setsize",
 		  "required": false,
 		  "disallowed": false,
@@ -5399,6 +6084,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -5422,6 +6121,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -5556,6 +6262,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -5579,6 +6299,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -5743,6 +6470,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -5766,6 +6507,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -5904,6 +6652,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -5927,6 +6689,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -6246,6 +7015,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -6269,6 +7052,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -6426,6 +7216,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -6449,6 +7253,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -6570,6 +7381,29 @@ var roleInfo = {
 	"subscript": {
 	  "name": "subscript",
 	  "fragID": "subscript",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"suggestion": {
+	  "name": "suggestion",
+	  "fragID": "suggestion",
 	  "parentRoles": [
 		"section"
 	  ],
@@ -6726,6 +7560,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -6749,6 +7597,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -6904,7 +7759,22 @@ var roleInfo = {
 	  "parentRoles": [
 		"section"
 	  ],
-	  "localprops": []
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
 	},
 	"textbox": {
 	  "name": "textbox",
@@ -7056,6 +7926,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -7079,6 +7963,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -7331,6 +8222,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -7354,6 +8259,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -7492,6 +8404,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -7515,6 +8441,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -7682,6 +8615,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -7705,6 +8652,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false
@@ -7854,6 +8808,20 @@ var roleInfo = {
 		  "deprecated": false
 		},
 		{
+		  "is": "property",
+		  "name": "aria-braillelabel",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-brailleroledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
 		  "is": "state",
 		  "name": "aria-busy",
 		  "required": false,
@@ -7877,6 +8845,13 @@ var roleInfo = {
 		{
 		  "is": "property",
 		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-description",
 		  "required": false,
 		  "disallowed": false,
 		  "deprecated": false

--- a/script/roleInfo.js
+++ b/script/roleInfo.js
@@ -1,8973 +1,8973 @@
 var roleInfo = {
-	"alert": {
-	  "name": "alert",
-	  "fragID": "alert",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"alertdialog": {
-	  "name": "alertdialog",
-	  "fragID": "alertdialog",
-	  "parentRoles": [
-		"alert",
-		"dialog"
-	  ],
-	  "localprops": []
-	},
-	"application": {
-	  "name": "application",
-	  "fragID": "application",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"article": {
-	  "name": "article",
-	  "fragID": "article",
-	  "parentRoles": [
-		"document"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"associationlist": {
-	  "name": "associationlist",
-	  "fragID": "associationlist",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"associationlistitemkey": {
-	  "name": "associationlistitemkey",
-	  "fragID": "associationlistitemkey",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"associationlistitemvalue": {
-	  "name": "associationlistitemvalue",
-	  "fragID": "associationlistitemvalue",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"banner": {
-	  "name": "banner",
-	  "fragID": "banner",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"blockquote": {
-	  "name": "blockquote",
-	  "fragID": "blockquote",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"button": {
-	  "name": "button",
-	  "fragID": "button",
-	  "parentRoles": [
-		"command"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-pressed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"caption": {
-	  "name": "caption",
-	  "fragID": "caption",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"cell": {
-	  "name": "cell",
-	  "fragID": "cell",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-colindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-colindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"checkbox": {
-	  "name": "checkbox",
-	  "fragID": "checkbox",
-	  "parentRoles": [
-		"input"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"code": {
-	  "name": "code",
-	  "fragID": "code",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"columnheader": {
-	  "name": "columnheader",
-	  "fragID": "columnheader",
-	  "parentRoles": [
-		"cell",
-		"gridcell",
-		"sectionhead"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-sort",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"combobox": {
-	  "name": "combobox",
-	  "fragID": "combobox",
-	  "parentRoles": [
-		"input"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-autocomplete",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"command": {
-	  "name": "command",
-	  "fragID": "command",
-	  "parentRoles": [
-		"widget"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"comment": {
-	  "name": "comment",
-	  "fragID": "comment",
-	  "parentRoles": [
-		"article"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"complementary": {
-	  "name": "complementary",
-	  "fragID": "complementary",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"composite": {
-	  "name": "composite",
-	  "fragID": "composite",
-	  "parentRoles": [
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"contentinfo": {
-	  "name": "contentinfo",
-	  "fragID": "contentinfo",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"definition": {
-	  "name": "definition",
-	  "fragID": "definition",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"deletion": {
-	  "name": "deletion",
-	  "fragID": "deletion",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"dialog": {
-	  "name": "dialog",
-	  "fragID": "dialog",
-	  "parentRoles": [
-		"window"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-modal",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"directory": {
-	  "name": "directory",
-	  "fragID": "directory",
-	  "parentRoles": [
-		"list"
-	  ],
-	  "localprops": []
-	},
-	"document": {
-	  "name": "document",
-	  "fragID": "document",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"emphasis": {
-	  "name": "emphasis",
-	  "fragID": "emphasis",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"feed": {
-	  "name": "feed",
-	  "fragID": "feed",
-	  "parentRoles": [
-		"list"
-	  ],
-	  "localprops": []
-	},
-	"figure": {
-	  "name": "figure",
-	  "fragID": "figure",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"form": {
-	  "name": "form",
-	  "fragID": "form",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"generic": {
-	  "name": "generic",
-	  "fragID": "generic",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"grid": {
-	  "name": "grid",
-	  "fragID": "grid",
-	  "parentRoles": [
-		"composite",
-		"table"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"gridcell": {
-	  "name": "gridcell",
-	  "fragID": "gridcell",
-	  "parentRoles": [
-		"cell",
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-colspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowspan",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"group": {
-	  "name": "group",
-	  "fragID": "group",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"heading": {
-	  "name": "heading",
-	  "fragID": "heading",
-	  "parentRoles": [
-		"sectionhead"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"img": {
-	  "name": "img",
-	  "fragID": "img",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"input": {
-	  "name": "input",
-	  "fragID": "input",
-	  "parentRoles": [
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"insertion": {
-	  "name": "insertion",
-	  "fragID": "insertion",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"label": {
-	  "name": "label",
-	  "fragID": "label",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"landmark": {
-	  "name": "landmark",
-	  "fragID": "landmark",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"legend": {
-	  "name": "legend",
-	  "fragID": "legend",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"link": {
-	  "name": "link",
-	  "fragID": "link",
-	  "parentRoles": [
-		"command"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"list": {
-	  "name": "list",
-	  "fragID": "list",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"listbox": {
-	  "name": "listbox",
-	  "fragID": "listbox",
-	  "parentRoles": [
-		"select"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"listitem": {
-	  "name": "listitem",
-	  "fragID": "listitem",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"log": {
-	  "name": "log",
-	  "fragID": "log",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"main": {
-	  "name": "main",
-	  "fragID": "main",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"mark": {
-	  "name": "mark",
-	  "fragID": "mark",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"marquee": {
-	  "name": "marquee",
-	  "fragID": "marquee",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"math": {
-	  "name": "math",
-	  "fragID": "math",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"meter": {
-	  "name": "meter",
-	  "fragID": "meter",
-	  "parentRoles": [
-		"range"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"menu": {
-	  "name": "menu",
-	  "fragID": "menu",
-	  "parentRoles": [
-		"select"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"menubar": {
-	  "name": "menubar",
-	  "fragID": "menubar",
-	  "parentRoles": [
-		"menu"
-	  ],
-	  "localprops": []
-	},
-	"menuitem": {
-	  "name": "menuitem",
-	  "fragID": "menuitem",
-	  "parentRoles": [
-		"command"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"menuitemcheckbox": {
-	  "name": "menuitemcheckbox",
-	  "fragID": "menuitemcheckbox",
-	  "parentRoles": [
-		"menuitem"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"menuitemradio": {
-	  "name": "menuitemradio",
-	  "fragID": "menuitemradio",
-	  "parentRoles": [
-		"menuitem"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"navigation": {
-	  "name": "navigation",
-	  "fragID": "navigation",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"none": {
-	  "name": "none",
-	  "fragID": "none",
-	  "parentRoles": [],
-	  "localprops": []
-	},
-	"note": {
-	  "name": "note",
-	  "fragID": "note",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"option": {
-	  "name": "option",
-	  "fragID": "option",
-	  "parentRoles": [
-		"input"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"paragraph": {
-	  "name": "paragraph",
-	  "fragID": "paragraph",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"presentation": {
-	  "name": "presentation",
-	  "fragID": "presentation",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"progressbar": {
-	  "name": "progressbar",
-	  "fragID": "progressbar",
-	  "parentRoles": [
-		"range",
-		"widget"
-	  ],
-	  "localprops": []
-	},
-	"radio": {
-	  "name": "radio",
-	  "fragID": "radio",
-	  "parentRoles": [
-		"input"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"radiogroup": {
-	  "name": "radiogroup",
-	  "fragID": "radiogroup",
-	  "parentRoles": [
-		"select"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"range": {
-	  "name": "range",
-	  "fragID": "range",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuetext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuetext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"region": {
-	  "name": "region",
-	  "fragID": "region",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"roletype": {
-	  "name": "roletype",
-	  "fragID": "roletype",
-	  "parentRoles": [],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"row": {
-	  "name": "row",
-	  "fragID": "row",
-	  "parentRoles": [
-		"group",
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-colindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-level",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindex",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowindextext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"rowgroup": {
-	  "name": "rowgroup",
-	  "fragID": "rowgroup",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": []
-	},
-	"rowheader": {
-	  "name": "rowheader",
-	  "fragID": "rowheader",
-	  "parentRoles": [
-		"cell",
-		"gridcell",
-		"sectionhead"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-sort",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"scrollbar": {
-	  "name": "scrollbar",
-	  "fragID": "scrollbar",
-	  "parentRoles": [
-		"range",
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"search": {
-	  "name": "search",
-	  "fragID": "search",
-	  "parentRoles": [
-		"landmark"
-	  ],
-	  "localprops": []
-	},
-	"searchbox": {
-	  "name": "searchbox",
-	  "fragID": "searchbox",
-	  "parentRoles": [
-		"textbox"
-	  ],
-	  "localprops": []
-	},
-	"section": {
-	  "name": "section",
-	  "fragID": "section",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"sectionhead": {
-	  "name": "sectionhead",
-	  "fragID": "sectionhead",
-	  "parentRoles": [
-		"structure"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"select": {
-	  "name": "select",
-	  "fragID": "select",
-	  "parentRoles": [
-		"composite",
-		"group"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"separator": {
-	  "name": "separator",
-	  "fragID": "separator",
-	  "parentRoles": [
-		"structure",
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuetext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"slider": {
-	  "name": "slider",
-	  "fragID": "slider",
-	  "parentRoles": [
-		"input",
-		"range"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"spinbutton": {
-	  "name": "spinbutton",
-	  "fragID": "spinbutton",
-	  "parentRoles": [
-		"composite",
-		"input",
-		"range"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemax",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuemin",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuenow",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-valuetext",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"status": {
-	  "name": "status",
-	  "fragID": "status",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"strong": {
-	  "name": "strong",
-	  "fragID": "strong",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"structure": {
-	  "name": "structure",
-	  "fragID": "structure",
-	  "parentRoles": [
-		"roletype"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"subscript": {
-	  "name": "subscript",
-	  "fragID": "subscript",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"suggestion": {
-	  "name": "suggestion",
-	  "fragID": "suggestion",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"superscript": {
-	  "name": "superscript",
-	  "fragID": "superscript",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"switch": {
-	  "name": "switch",
-	  "fragID": "switch",
-	  "parentRoles": [
-		"checkbox"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-checked",
-		  "required": true,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"tab": {
-	  "name": "tab",
-	  "fragID": "tab",
-	  "parentRoles": [
-		"sectionhead",
-		"widget"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-posinset",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-selected",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-setsize",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"table": {
-	  "name": "table",
-	  "fragID": "table",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-colcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-colcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-rowcount",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"tablist": {
-	  "name": "tablist",
-	  "fragID": "tablist",
-	  "parentRoles": [
-		"composite"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"tabpanel": {
-	  "name": "tabpanel",
-	  "fragID": "tabpanel",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"term": {
-	  "name": "term",
-	  "fragID": "term",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": true,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"textbox": {
-	  "name": "textbox",
-	  "fragID": "textbox",
-	  "parentRoles": [
-		"input"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-autocomplete",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-multiline",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-placeholder",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-autocomplete",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-multiline",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-placeholder",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-readonly",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"time": {
-	  "name": "time",
-	  "fragID": "time",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"timer": {
-	  "name": "timer",
-	  "fragID": "timer",
-	  "parentRoles": [
-		"status"
-	  ],
-	  "localprops": []
-	},
-	"toolbar": {
-	  "name": "toolbar",
-	  "fragID": "toolbar",
-	  "parentRoles": [
-		"group"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"tooltip": {
-	  "name": "tooltip",
-	  "fragID": "tooltip",
-	  "parentRoles": [
-		"section"
-	  ],
-	  "localprops": []
-	},
-	"tree": {
-	  "name": "tree",
-	  "fragID": "tree",
-	  "parentRoles": [
-		"select"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-multiselectable",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-required",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-orientation",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-activedescendant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"treegrid": {
-	  "name": "treegrid",
-	  "fragID": "treegrid",
-	  "parentRoles": [
-		"grid",
-		"tree"
-	  ],
-	  "localprops": []
-	},
-	"treeitem": {
-	  "name": "treeitem",
-	  "fragID": "treeitem",
-	  "parentRoles": [
-		"listitem",
-		"option"
-	  ],
-	  "localprops": [
-		{
-		  "is": "state",
-		  "name": "aria-expanded",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"widget": {
-	  "name": "widget",
-	  "fragID": "widget",
-	  "parentRoles": [
-		"roletype"
-	  ],
-	  "localprops": [],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	},
-	"window": {
-	  "name": "window",
-	  "fragID": "window",
-	  "parentRoles": [
-		"roletype"
-	  ],
-	  "localprops": [
-		{
-		  "is": "property",
-		  "name": "aria-modal",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ],
-	  "allprops": [
-		{
-		  "is": "property",
-		  "name": "aria-modal",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-atomic",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-braillelabel",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-brailleroledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-busy",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-controls",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-current",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-describedby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-description",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-details",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-disabled",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-dropeffect",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-errormessage",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-flowto",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-grabbed",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-haspopup",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "state",
-		  "name": "aria-hidden",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "state",
-		  "name": "aria-invalid",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": true
-		},
-		{
-		  "is": "property",
-		  "name": "aria-keyshortcuts",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-label",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-labelledby",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-live",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-owns",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-relevant",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		},
-		{
-		  "is": "property",
-		  "name": "aria-roledescription",
-		  "required": false,
-		  "disallowed": false,
-		  "deprecated": false
-		}
-	  ]
-	}
+  "alert": {
+    "name": "alert",
+    "fragID": "alert",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "alertdialog": {
+    "name": "alertdialog",
+    "fragID": "alertdialog",
+    "parentRoles": [
+      "alert",
+      "dialog"
+    ],
+    "localprops": []
+  },
+  "application": {
+    "name": "application",
+    "fragID": "application",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "article": {
+    "name": "article",
+    "fragID": "article",
+    "parentRoles": [
+      "document"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "associationlist": {
+    "name": "associationlist",
+    "fragID": "associationlist",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "associationlistitemkey": {
+    "name": "associationlistitemkey",
+    "fragID": "associationlistitemkey",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "associationlistitemvalue": {
+    "name": "associationlistitemvalue",
+    "fragID": "associationlistitemvalue",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "banner": {
+    "name": "banner",
+    "fragID": "banner",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "blockquote": {
+    "name": "blockquote",
+    "fragID": "blockquote",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "button": {
+    "name": "button",
+    "fragID": "button",
+    "parentRoles": [
+      "command"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-pressed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "caption": {
+    "name": "caption",
+    "fragID": "caption",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "cell": {
+    "name": "cell",
+    "fragID": "cell",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-colindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-colindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "checkbox": {
+    "name": "checkbox",
+    "fragID": "checkbox",
+    "parentRoles": [
+      "input"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "code": {
+    "name": "code",
+    "fragID": "code",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "columnheader": {
+    "name": "columnheader",
+    "fragID": "columnheader",
+    "parentRoles": [
+      "cell",
+      "gridcell",
+      "sectionhead"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-sort",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "combobox": {
+    "name": "combobox",
+    "fragID": "combobox",
+    "parentRoles": [
+      "input"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-autocomplete",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "command": {
+    "name": "command",
+    "fragID": "command",
+    "parentRoles": [
+      "widget"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "comment": {
+    "name": "comment",
+    "fragID": "comment",
+    "parentRoles": [
+      "article"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "complementary": {
+    "name": "complementary",
+    "fragID": "complementary",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "composite": {
+    "name": "composite",
+    "fragID": "composite",
+    "parentRoles": [
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "contentinfo": {
+    "name": "contentinfo",
+    "fragID": "contentinfo",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "definition": {
+    "name": "definition",
+    "fragID": "definition",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "deletion": {
+    "name": "deletion",
+    "fragID": "deletion",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "dialog": {
+    "name": "dialog",
+    "fragID": "dialog",
+    "parentRoles": [
+      "window"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-modal",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "directory": {
+    "name": "directory",
+    "fragID": "directory",
+    "parentRoles": [
+      "list"
+    ],
+    "localprops": []
+  },
+  "document": {
+    "name": "document",
+    "fragID": "document",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "emphasis": {
+    "name": "emphasis",
+    "fragID": "emphasis",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "feed": {
+    "name": "feed",
+    "fragID": "feed",
+    "parentRoles": [
+      "list"
+    ],
+    "localprops": []
+  },
+  "figure": {
+    "name": "figure",
+    "fragID": "figure",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "form": {
+    "name": "form",
+    "fragID": "form",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "generic": {
+    "name": "generic",
+    "fragID": "generic",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "grid": {
+    "name": "grid",
+    "fragID": "grid",
+    "parentRoles": [
+      "composite",
+      "table"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "gridcell": {
+    "name": "gridcell",
+    "fragID": "gridcell",
+    "parentRoles": [
+      "cell",
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-colspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowspan",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "group": {
+    "name": "group",
+    "fragID": "group",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "heading": {
+    "name": "heading",
+    "fragID": "heading",
+    "parentRoles": [
+      "sectionhead"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "img": {
+    "name": "img",
+    "fragID": "img",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "input": {
+    "name": "input",
+    "fragID": "input",
+    "parentRoles": [
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "insertion": {
+    "name": "insertion",
+    "fragID": "insertion",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "label": {
+    "name": "label",
+    "fragID": "label",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "landmark": {
+    "name": "landmark",
+    "fragID": "landmark",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "legend": {
+    "name": "legend",
+    "fragID": "legend",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "link": {
+    "name": "link",
+    "fragID": "link",
+    "parentRoles": [
+      "command"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "list": {
+    "name": "list",
+    "fragID": "list",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "listbox": {
+    "name": "listbox",
+    "fragID": "listbox",
+    "parentRoles": [
+      "select"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "listitem": {
+    "name": "listitem",
+    "fragID": "listitem",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "log": {
+    "name": "log",
+    "fragID": "log",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "main": {
+    "name": "main",
+    "fragID": "main",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "mark": {
+    "name": "mark",
+    "fragID": "mark",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "marquee": {
+    "name": "marquee",
+    "fragID": "marquee",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "math": {
+    "name": "math",
+    "fragID": "math",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "meter": {
+    "name": "meter",
+    "fragID": "meter",
+    "parentRoles": [
+      "range"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "menu": {
+    "name": "menu",
+    "fragID": "menu",
+    "parentRoles": [
+      "select"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "menubar": {
+    "name": "menubar",
+    "fragID": "menubar",
+    "parentRoles": [
+      "menu"
+    ],
+    "localprops": []
+  },
+  "menuitem": {
+    "name": "menuitem",
+    "fragID": "menuitem",
+    "parentRoles": [
+      "command"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "menuitemcheckbox": {
+    "name": "menuitemcheckbox",
+    "fragID": "menuitemcheckbox",
+    "parentRoles": [
+      "menuitem"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "menuitemradio": {
+    "name": "menuitemradio",
+    "fragID": "menuitemradio",
+    "parentRoles": [
+      "menuitem"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "navigation": {
+    "name": "navigation",
+    "fragID": "navigation",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "none": {
+    "name": "none",
+    "fragID": "none",
+    "parentRoles": [],
+    "localprops": []
+  },
+  "note": {
+    "name": "note",
+    "fragID": "note",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "option": {
+    "name": "option",
+    "fragID": "option",
+    "parentRoles": [
+      "input"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "paragraph": {
+    "name": "paragraph",
+    "fragID": "paragraph",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "presentation": {
+    "name": "presentation",
+    "fragID": "presentation",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "progressbar": {
+    "name": "progressbar",
+    "fragID": "progressbar",
+    "parentRoles": [
+      "range",
+      "widget"
+    ],
+    "localprops": []
+  },
+  "radio": {
+    "name": "radio",
+    "fragID": "radio",
+    "parentRoles": [
+      "input"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "radiogroup": {
+    "name": "radiogroup",
+    "fragID": "radiogroup",
+    "parentRoles": [
+      "select"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "range": {
+    "name": "range",
+    "fragID": "range",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuetext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuetext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "region": {
+    "name": "region",
+    "fragID": "region",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "roletype": {
+    "name": "roletype",
+    "fragID": "roletype",
+    "parentRoles": [],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "row": {
+    "name": "row",
+    "fragID": "row",
+    "parentRoles": [
+      "group",
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-colindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-level",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindex",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowindextext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "rowgroup": {
+    "name": "rowgroup",
+    "fragID": "rowgroup",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": []
+  },
+  "rowheader": {
+    "name": "rowheader",
+    "fragID": "rowheader",
+    "parentRoles": [
+      "cell",
+      "gridcell",
+      "sectionhead"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-sort",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "scrollbar": {
+    "name": "scrollbar",
+    "fragID": "scrollbar",
+    "parentRoles": [
+      "range",
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "search": {
+    "name": "search",
+    "fragID": "search",
+    "parentRoles": [
+      "landmark"
+    ],
+    "localprops": []
+  },
+  "searchbox": {
+    "name": "searchbox",
+    "fragID": "searchbox",
+    "parentRoles": [
+      "textbox"
+    ],
+    "localprops": []
+  },
+  "section": {
+    "name": "section",
+    "fragID": "section",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "sectionhead": {
+    "name": "sectionhead",
+    "fragID": "sectionhead",
+    "parentRoles": [
+      "structure"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "select": {
+    "name": "select",
+    "fragID": "select",
+    "parentRoles": [
+      "composite",
+      "group"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "separator": {
+    "name": "separator",
+    "fragID": "separator",
+    "parentRoles": [
+      "structure",
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuetext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "slider": {
+    "name": "slider",
+    "fragID": "slider",
+    "parentRoles": [
+      "input",
+      "range"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "spinbutton": {
+    "name": "spinbutton",
+    "fragID": "spinbutton",
+    "parentRoles": [
+      "composite",
+      "input",
+      "range"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemax",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuemin",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuenow",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-valuetext",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "status": {
+    "name": "status",
+    "fragID": "status",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "strong": {
+    "name": "strong",
+    "fragID": "strong",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "structure": {
+    "name": "structure",
+    "fragID": "structure",
+    "parentRoles": [
+      "roletype"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "subscript": {
+    "name": "subscript",
+    "fragID": "subscript",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "suggestion": {
+    "name": "suggestion",
+    "fragID": "suggestion",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "superscript": {
+    "name": "superscript",
+    "fragID": "superscript",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "switch": {
+    "name": "switch",
+    "fragID": "switch",
+    "parentRoles": [
+      "checkbox"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "tab": {
+    "name": "tab",
+    "fragID": "tab",
+    "parentRoles": [
+      "sectionhead",
+      "widget"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-posinset",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-selected",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-setsize",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "table": {
+    "name": "table",
+    "fragID": "table",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-colcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-colcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-rowcount",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "tablist": {
+    "name": "tablist",
+    "fragID": "tablist",
+    "parentRoles": [
+      "composite"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "tabpanel": {
+    "name": "tabpanel",
+    "fragID": "tabpanel",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "term": {
+    "name": "term",
+    "fragID": "term",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": true,
+        "deprecated": false
+      }
+    ]
+  },
+  "textbox": {
+    "name": "textbox",
+    "fragID": "textbox",
+    "parentRoles": [
+      "input"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-autocomplete",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-multiline",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-placeholder",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-autocomplete",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-multiline",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-placeholder",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-readonly",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "time": {
+    "name": "time",
+    "fragID": "time",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "timer": {
+    "name": "timer",
+    "fragID": "timer",
+    "parentRoles": [
+      "status"
+    ],
+    "localprops": []
+  },
+  "toolbar": {
+    "name": "toolbar",
+    "fragID": "toolbar",
+    "parentRoles": [
+      "group"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "tooltip": {
+    "name": "tooltip",
+    "fragID": "tooltip",
+    "parentRoles": [
+      "section"
+    ],
+    "localprops": []
+  },
+  "tree": {
+    "name": "tree",
+    "fragID": "tree",
+    "parentRoles": [
+      "select"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-multiselectable",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-required",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-orientation",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-activedescendant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "treegrid": {
+    "name": "treegrid",
+    "fragID": "treegrid",
+    "parentRoles": [
+      "grid",
+      "tree"
+    ],
+    "localprops": []
+  },
+  "treeitem": {
+    "name": "treeitem",
+    "fragID": "treeitem",
+    "parentRoles": [
+      "listitem",
+      "option"
+    ],
+    "localprops": [
+      {
+        "is": "state",
+        "name": "aria-expanded",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "widget": {
+    "name": "widget",
+    "fragID": "widget",
+    "parentRoles": [
+      "roletype"
+    ],
+    "localprops": [],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "window": {
+    "name": "window",
+    "fragID": "window",
+    "parentRoles": [
+      "roletype"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-modal",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ],
+    "allprops": [
+      {
+        "is": "property",
+        "name": "aria-modal",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-atomic",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-braillelabel",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-brailleroledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-busy",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-controls",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-current",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-describedby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-description",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-details",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-disabled",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-dropeffect",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-errormessage",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-flowto",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-grabbed",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-haspopup",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "state",
+        "name": "aria-hidden",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "state",
+        "name": "aria-invalid",
+        "required": false,
+        "disallowed": false,
+        "deprecated": true
+      },
+      {
+        "is": "property",
+        "name": "aria-keyshortcuts",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-label",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-labelledby",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-live",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-owns",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-relevant",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      },
+      {
+        "is": "property",
+        "name": "aria-roledescription",
+        "required": false,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
   }
+}

--- a/script/roleInfo.js
+++ b/script/roleInfo.js
@@ -1,8973 +1,7998 @@
 var roleInfo = {
-  "alert": {
-    "name": "alert",
-    "fragID": "alert",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "alertdialog": {
-    "name": "alertdialog",
-    "fragID": "alertdialog",
-    "parentRoles": [
-      "alert",
-      "dialog"
-    ],
-    "localprops": []
-  },
-  "application": {
-    "name": "application",
-    "fragID": "application",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "article": {
-    "name": "article",
-    "fragID": "article",
-    "parentRoles": [
-      "document"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "associationlist": {
-    "name": "associationlist",
-    "fragID": "associationlist",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "associationlistitemkey": {
-    "name": "associationlistitemkey",
-    "fragID": "associationlistitemkey",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "associationlistitemvalue": {
-    "name": "associationlistitemvalue",
-    "fragID": "associationlistitemvalue",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "banner": {
-    "name": "banner",
-    "fragID": "banner",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "blockquote": {
-    "name": "blockquote",
-    "fragID": "blockquote",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "button": {
-    "name": "button",
-    "fragID": "button",
-    "parentRoles": [
-      "command"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-pressed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "caption": {
-    "name": "caption",
-    "fragID": "caption",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "cell": {
-    "name": "cell",
-    "fragID": "cell",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-colindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-colindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "checkbox": {
-    "name": "checkbox",
-    "fragID": "checkbox",
-    "parentRoles": [
-      "input"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "code": {
-    "name": "code",
-    "fragID": "code",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "columnheader": {
-    "name": "columnheader",
-    "fragID": "columnheader",
-    "parentRoles": [
-      "cell",
-      "gridcell",
-      "sectionhead"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-sort",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "combobox": {
-    "name": "combobox",
-    "fragID": "combobox",
-    "parentRoles": [
-      "input"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-autocomplete",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "command": {
-    "name": "command",
-    "fragID": "command",
-    "parentRoles": [
-      "widget"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "comment": {
-    "name": "comment",
-    "fragID": "comment",
-    "parentRoles": [
-      "article"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "complementary": {
-    "name": "complementary",
-    "fragID": "complementary",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "composite": {
-    "name": "composite",
-    "fragID": "composite",
-    "parentRoles": [
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "contentinfo": {
-    "name": "contentinfo",
-    "fragID": "contentinfo",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "definition": {
-    "name": "definition",
-    "fragID": "definition",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "deletion": {
-    "name": "deletion",
-    "fragID": "deletion",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "dialog": {
-    "name": "dialog",
-    "fragID": "dialog",
-    "parentRoles": [
-      "window"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-modal",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "directory": {
-    "name": "directory",
-    "fragID": "directory",
-    "parentRoles": [
-      "list"
-    ],
-    "localprops": []
-  },
-  "document": {
-    "name": "document",
-    "fragID": "document",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "emphasis": {
-    "name": "emphasis",
-    "fragID": "emphasis",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "feed": {
-    "name": "feed",
-    "fragID": "feed",
-    "parentRoles": [
-      "list"
-    ],
-    "localprops": []
-  },
-  "figure": {
-    "name": "figure",
-    "fragID": "figure",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "form": {
-    "name": "form",
-    "fragID": "form",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "generic": {
-    "name": "generic",
-    "fragID": "generic",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "grid": {
-    "name": "grid",
-    "fragID": "grid",
-    "parentRoles": [
-      "composite",
-      "table"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "gridcell": {
-    "name": "gridcell",
-    "fragID": "gridcell",
-    "parentRoles": [
-      "cell",
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-colspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowspan",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "group": {
-    "name": "group",
-    "fragID": "group",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "heading": {
-    "name": "heading",
-    "fragID": "heading",
-    "parentRoles": [
-      "sectionhead"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "img": {
-    "name": "img",
-    "fragID": "img",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "input": {
-    "name": "input",
-    "fragID": "input",
-    "parentRoles": [
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "insertion": {
-    "name": "insertion",
-    "fragID": "insertion",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "label": {
-    "name": "label",
-    "fragID": "label",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "landmark": {
-    "name": "landmark",
-    "fragID": "landmark",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "legend": {
-    "name": "legend",
-    "fragID": "legend",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "link": {
-    "name": "link",
-    "fragID": "link",
-    "parentRoles": [
-      "command"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "list": {
-    "name": "list",
-    "fragID": "list",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "listbox": {
-    "name": "listbox",
-    "fragID": "listbox",
-    "parentRoles": [
-      "select"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "listitem": {
-    "name": "listitem",
-    "fragID": "listitem",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "log": {
-    "name": "log",
-    "fragID": "log",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "main": {
-    "name": "main",
-    "fragID": "main",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "mark": {
-    "name": "mark",
-    "fragID": "mark",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "marquee": {
-    "name": "marquee",
-    "fragID": "marquee",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "math": {
-    "name": "math",
-    "fragID": "math",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "meter": {
-    "name": "meter",
-    "fragID": "meter",
-    "parentRoles": [
-      "range"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "menu": {
-    "name": "menu",
-    "fragID": "menu",
-    "parentRoles": [
-      "select"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "menubar": {
-    "name": "menubar",
-    "fragID": "menubar",
-    "parentRoles": [
-      "menu"
-    ],
-    "localprops": []
-  },
-  "menuitem": {
-    "name": "menuitem",
-    "fragID": "menuitem",
-    "parentRoles": [
-      "command"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "menuitemcheckbox": {
-    "name": "menuitemcheckbox",
-    "fragID": "menuitemcheckbox",
-    "parentRoles": [
-      "menuitem"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "menuitemradio": {
-    "name": "menuitemradio",
-    "fragID": "menuitemradio",
-    "parentRoles": [
-      "menuitem"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "navigation": {
-    "name": "navigation",
-    "fragID": "navigation",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "none": {
-    "name": "none",
-    "fragID": "none",
-    "parentRoles": [],
-    "localprops": []
-  },
-  "note": {
-    "name": "note",
-    "fragID": "note",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "option": {
-    "name": "option",
-    "fragID": "option",
-    "parentRoles": [
-      "input"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "paragraph": {
-    "name": "paragraph",
-    "fragID": "paragraph",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "presentation": {
-    "name": "presentation",
-    "fragID": "presentation",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "progressbar": {
-    "name": "progressbar",
-    "fragID": "progressbar",
-    "parentRoles": [
-      "range",
-      "widget"
-    ],
-    "localprops": []
-  },
-  "radio": {
-    "name": "radio",
-    "fragID": "radio",
-    "parentRoles": [
-      "input"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "radiogroup": {
-    "name": "radiogroup",
-    "fragID": "radiogroup",
-    "parentRoles": [
-      "select"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "range": {
-    "name": "range",
-    "fragID": "range",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuetext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuetext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "region": {
-    "name": "region",
-    "fragID": "region",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "roletype": {
-    "name": "roletype",
-    "fragID": "roletype",
-    "parentRoles": [],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "row": {
-    "name": "row",
-    "fragID": "row",
-    "parentRoles": [
-      "group",
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-colindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-level",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindex",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowindextext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "rowgroup": {
-    "name": "rowgroup",
-    "fragID": "rowgroup",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": []
-  },
-  "rowheader": {
-    "name": "rowheader",
-    "fragID": "rowheader",
-    "parentRoles": [
-      "cell",
-      "gridcell",
-      "sectionhead"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-sort",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "scrollbar": {
-    "name": "scrollbar",
-    "fragID": "scrollbar",
-    "parentRoles": [
-      "range",
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "search": {
-    "name": "search",
-    "fragID": "search",
-    "parentRoles": [
-      "landmark"
-    ],
-    "localprops": []
-  },
-  "searchbox": {
-    "name": "searchbox",
-    "fragID": "searchbox",
-    "parentRoles": [
-      "textbox"
-    ],
-    "localprops": []
-  },
-  "section": {
-    "name": "section",
-    "fragID": "section",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "sectionhead": {
-    "name": "sectionhead",
-    "fragID": "sectionhead",
-    "parentRoles": [
-      "structure"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "select": {
-    "name": "select",
-    "fragID": "select",
-    "parentRoles": [
-      "composite",
-      "group"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "separator": {
-    "name": "separator",
-    "fragID": "separator",
-    "parentRoles": [
-      "structure",
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuetext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "slider": {
-    "name": "slider",
-    "fragID": "slider",
-    "parentRoles": [
-      "input",
-      "range"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "spinbutton": {
-    "name": "spinbutton",
-    "fragID": "spinbutton",
-    "parentRoles": [
-      "composite",
-      "input",
-      "range"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemax",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuemin",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-valuetext",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "status": {
-    "name": "status",
-    "fragID": "status",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "strong": {
-    "name": "strong",
-    "fragID": "strong",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "structure": {
-    "name": "structure",
-    "fragID": "structure",
-    "parentRoles": [
-      "roletype"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "subscript": {
-    "name": "subscript",
-    "fragID": "subscript",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "suggestion": {
-    "name": "suggestion",
-    "fragID": "suggestion",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "superscript": {
-    "name": "superscript",
-    "fragID": "superscript",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "switch": {
-    "name": "switch",
-    "fragID": "switch",
-    "parentRoles": [
-      "checkbox"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-checked",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "tab": {
-    "name": "tab",
-    "fragID": "tab",
-    "parentRoles": [
-      "sectionhead",
-      "widget"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-posinset",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-selected",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-setsize",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "table": {
-    "name": "table",
-    "fragID": "table",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-colcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-colcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-rowcount",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "tablist": {
-    "name": "tablist",
-    "fragID": "tablist",
-    "parentRoles": [
-      "composite"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "tabpanel": {
-    "name": "tabpanel",
-    "fragID": "tabpanel",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "term": {
-    "name": "term",
-    "fragID": "term",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": true,
-        "deprecated": false
-      }
-    ]
-  },
-  "textbox": {
-    "name": "textbox",
-    "fragID": "textbox",
-    "parentRoles": [
-      "input"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-autocomplete",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-multiline",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-placeholder",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-autocomplete",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-multiline",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-placeholder",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-readonly",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "time": {
-    "name": "time",
-    "fragID": "time",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "timer": {
-    "name": "timer",
-    "fragID": "timer",
-    "parentRoles": [
-      "status"
-    ],
-    "localprops": []
-  },
-  "toolbar": {
-    "name": "toolbar",
-    "fragID": "toolbar",
-    "parentRoles": [
-      "group"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "tooltip": {
-    "name": "tooltip",
-    "fragID": "tooltip",
-    "parentRoles": [
-      "section"
-    ],
-    "localprops": []
-  },
-  "tree": {
-    "name": "tree",
-    "fragID": "tree",
-    "parentRoles": [
-      "select"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-multiselectable",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-required",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-orientation",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-activedescendant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "treegrid": {
-    "name": "treegrid",
-    "fragID": "treegrid",
-    "parentRoles": [
-      "grid",
-      "tree"
-    ],
-    "localprops": []
-  },
-  "treeitem": {
-    "name": "treeitem",
-    "fragID": "treeitem",
-    "parentRoles": [
-      "listitem",
-      "option"
-    ],
-    "localprops": [
-      {
-        "is": "state",
-        "name": "aria-expanded",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "widget": {
-    "name": "widget",
-    "fragID": "widget",
-    "parentRoles": [
-      "roletype"
-    ],
-    "localprops": [],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
-  "window": {
-    "name": "window",
-    "fragID": "window",
-    "parentRoles": [
-      "roletype"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-modal",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ],
-    "allprops": [
-      {
-        "is": "property",
-        "name": "aria-modal",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-atomic",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-braillelabel",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-brailleroledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-busy",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-controls",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-current",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-describedby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-description",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-details",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-disabled",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-dropeffect",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-errormessage",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-flowto",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-grabbed",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-haspopup",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "state",
-        "name": "aria-hidden",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "state",
-        "name": "aria-invalid",
-        "required": false,
-        "disallowed": false,
-        "deprecated": true
-      },
-      {
-        "is": "property",
-        "name": "aria-keyshortcuts",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-label",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-labelledby",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-live",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-owns",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-relevant",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      },
-      {
-        "is": "property",
-        "name": "aria-roledescription",
-        "required": false,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
+	"alert": {
+	  "name": "alert",
+	  "fragID": "alert",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"alertdialog": {
+	  "name": "alertdialog",
+	  "fragID": "alertdialog",
+	  "parentRoles": [
+		"alert",
+		"dialog"
+	  ],
+	  "localprops": []
+	},
+	"application": {
+	  "name": "application",
+	  "fragID": "application",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"article": {
+	  "name": "article",
+	  "fragID": "article",
+	  "parentRoles": [
+		"document"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"banner": {
+	  "name": "banner",
+	  "fragID": "banner",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"blockquote": {
+	  "name": "blockquote",
+	  "fragID": "blockquote",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"button": {
+	  "name": "button",
+	  "fragID": "button",
+	  "parentRoles": [
+		"command"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-pressed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"caption": {
+	  "name": "caption",
+	  "fragID": "caption",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"cell": {
+	  "name": "cell",
+	  "fragID": "cell",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-colindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-colspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-colindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-colspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"checkbox": {
+	  "name": "checkbox",
+	  "fragID": "checkbox",
+	  "parentRoles": [
+		"input"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"code": {
+	  "name": "code",
+	  "fragID": "code",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"columnheader": {
+	  "name": "columnheader",
+	  "fragID": "columnheader",
+	  "parentRoles": [
+		"cell",
+		"gridcell",
+		"sectionhead"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-sort",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"combobox": {
+	  "name": "combobox",
+	  "fragID": "combobox",
+	  "parentRoles": [
+		"input"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-autocomplete",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"command": {
+	  "name": "command",
+	  "fragID": "command",
+	  "parentRoles": [
+		"widget"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"complementary": {
+	  "name": "complementary",
+	  "fragID": "complementary",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"composite": {
+	  "name": "composite",
+	  "fragID": "composite",
+	  "parentRoles": [
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"contentinfo": {
+	  "name": "contentinfo",
+	  "fragID": "contentinfo",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"definition": {
+	  "name": "definition",
+	  "fragID": "definition",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"deletion": {
+	  "name": "deletion",
+	  "fragID": "deletion",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"dialog": {
+	  "name": "dialog",
+	  "fragID": "dialog",
+	  "parentRoles": [
+		"window"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-modal",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"directory": {
+	  "name": "directory",
+	  "fragID": "directory",
+	  "parentRoles": [
+		"list"
+	  ],
+	  "localprops": []
+	},
+	"document": {
+	  "name": "document",
+	  "fragID": "document",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"emphasis": {
+	  "name": "emphasis",
+	  "fragID": "emphasis",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"feed": {
+	  "name": "feed",
+	  "fragID": "feed",
+	  "parentRoles": [
+		"list"
+	  ],
+	  "localprops": []
+	},
+	"figure": {
+	  "name": "figure",
+	  "fragID": "figure",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"form": {
+	  "name": "form",
+	  "fragID": "form",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"generic": {
+	  "name": "generic",
+	  "fragID": "generic",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"grid": {
+	  "name": "grid",
+	  "fragID": "grid",
+	  "parentRoles": [
+		"composite",
+		"table"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-colcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"gridcell": {
+	  "name": "gridcell",
+	  "fragID": "gridcell",
+	  "parentRoles": [
+		"cell",
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-colindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-colspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowspan",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"group": {
+	  "name": "group",
+	  "fragID": "group",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"heading": {
+	  "name": "heading",
+	  "fragID": "heading",
+	  "parentRoles": [
+		"sectionhead"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"img": {
+	  "name": "img",
+	  "fragID": "img",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"input": {
+	  "name": "input",
+	  "fragID": "input",
+	  "parentRoles": [
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"insertion": {
+	  "name": "insertion",
+	  "fragID": "insertion",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"landmark": {
+	  "name": "landmark",
+	  "fragID": "landmark",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"link": {
+	  "name": "link",
+	  "fragID": "link",
+	  "parentRoles": [
+		"command"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"list": {
+	  "name": "list",
+	  "fragID": "list",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"listbox": {
+	  "name": "listbox",
+	  "fragID": "listbox",
+	  "parentRoles": [
+		"select"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"listitem": {
+	  "name": "listitem",
+	  "fragID": "listitem",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"log": {
+	  "name": "log",
+	  "fragID": "log",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"main": {
+	  "name": "main",
+	  "fragID": "main",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"marquee": {
+	  "name": "marquee",
+	  "fragID": "marquee",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"math": {
+	  "name": "math",
+	  "fragID": "math",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"meter": {
+	  "name": "meter",
+	  "fragID": "meter",
+	  "parentRoles": [
+		"range"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"menu": {
+	  "name": "menu",
+	  "fragID": "menu",
+	  "parentRoles": [
+		"select"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"menubar": {
+	  "name": "menubar",
+	  "fragID": "menubar",
+	  "parentRoles": [
+		"menu"
+	  ],
+	  "localprops": []
+	},
+	"menuitem": {
+	  "name": "menuitem",
+	  "fragID": "menuitem",
+	  "parentRoles": [
+		"command"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"menuitemcheckbox": {
+	  "name": "menuitemcheckbox",
+	  "fragID": "menuitemcheckbox",
+	  "parentRoles": [
+		"menuitem"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"menuitemradio": {
+	  "name": "menuitemradio",
+	  "fragID": "menuitemradio",
+	  "parentRoles": [
+		"menuitemcheckbox"
+	  ],
+	  "localprops": []
+	},
+	"navigation": {
+	  "name": "navigation",
+	  "fragID": "navigation",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"none": {
+	  "name": "none",
+	  "fragID": "none",
+	  "parentRoles": [],
+	  "localprops": []
+	},
+	"note": {
+	  "name": "note",
+	  "fragID": "note",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"option": {
+	  "name": "option",
+	  "fragID": "option",
+	  "parentRoles": [
+		"input"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"paragraph": {
+	  "name": "paragraph",
+	  "fragID": "paragraph",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"presentation": {
+	  "name": "presentation",
+	  "fragID": "presentation",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"progressbar": {
+	  "name": "progressbar",
+	  "fragID": "progressbar",
+	  "parentRoles": [
+		"range",
+		"widget"
+	  ],
+	  "localprops": []
+	},
+	"radio": {
+	  "name": "radio",
+	  "fragID": "radio",
+	  "parentRoles": [
+		"input"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"radiogroup": {
+	  "name": "radiogroup",
+	  "fragID": "radiogroup",
+	  "parentRoles": [
+		"select"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"range": {
+	  "name": "range",
+	  "fragID": "range",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuetext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuetext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"region": {
+	  "name": "region",
+	  "fragID": "region",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"roletype": {
+	  "name": "roletype",
+	  "fragID": "roletype",
+	  "parentRoles": [],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"row": {
+	  "name": "row",
+	  "fragID": "row",
+	  "parentRoles": [
+		"group",
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-colindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-level",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowindex",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"rowgroup": {
+	  "name": "rowgroup",
+	  "fragID": "rowgroup",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": []
+	},
+	"rowheader": {
+	  "name": "rowheader",
+	  "fragID": "rowheader",
+	  "parentRoles": [
+		"cell",
+		"gridcell",
+		"sectionhead"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-sort",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"scrollbar": {
+	  "name": "scrollbar",
+	  "fragID": "scrollbar",
+	  "parentRoles": [
+		"range",
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"search": {
+	  "name": "search",
+	  "fragID": "search",
+	  "parentRoles": [
+		"landmark"
+	  ],
+	  "localprops": []
+	},
+	"searchbox": {
+	  "name": "searchbox",
+	  "fragID": "searchbox",
+	  "parentRoles": [
+		"textbox"
+	  ],
+	  "localprops": []
+	},
+	"section": {
+	  "name": "section",
+	  "fragID": "section",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"sectionhead": {
+	  "name": "sectionhead",
+	  "fragID": "sectionhead",
+	  "parentRoles": [
+		"structure"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"select": {
+	  "name": "select",
+	  "fragID": "select",
+	  "parentRoles": [
+		"composite",
+		"group"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"separator": {
+	  "name": "separator",
+	  "fragID": "separator",
+	  "parentRoles": [
+		"structure",
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuetext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"slider": {
+	  "name": "slider",
+	  "fragID": "slider",
+	  "parentRoles": [
+		"input",
+		"range"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"spinbutton": {
+	  "name": "spinbutton",
+	  "fragID": "spinbutton",
+	  "parentRoles": [
+		"composite",
+		"input",
+		"range"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemax",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuemin",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuenow",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-valuetext",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"status": {
+	  "name": "status",
+	  "fragID": "status",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"strong": {
+	  "name": "strong",
+	  "fragID": "strong",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"structure": {
+	  "name": "structure",
+	  "fragID": "structure",
+	  "parentRoles": [
+		"roletype"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"subscript": {
+	  "name": "subscript",
+	  "fragID": "subscript",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"superscript": {
+	  "name": "superscript",
+	  "fragID": "superscript",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": true,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"switch": {
+	  "name": "switch",
+	  "fragID": "switch",
+	  "parentRoles": [
+		"checkbox"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-checked",
+		  "required": true,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"tab": {
+	  "name": "tab",
+	  "fragID": "tab",
+	  "parentRoles": [
+		"sectionhead",
+		"widget"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-posinset",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-selected",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-setsize",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"table": {
+	  "name": "table",
+	  "fragID": "table",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-colcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-colcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-rowcount",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"tablist": {
+	  "name": "tablist",
+	  "fragID": "tablist",
+	  "parentRoles": [
+		"composite"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"tabpanel": {
+	  "name": "tabpanel",
+	  "fragID": "tabpanel",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"term": {
+	  "name": "term",
+	  "fragID": "term",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"textbox": {
+	  "name": "textbox",
+	  "fragID": "textbox",
+	  "parentRoles": [
+		"input"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-autocomplete",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-multiline",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-placeholder",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-autocomplete",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-multiline",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-placeholder",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-readonly",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"time": {
+	  "name": "time",
+	  "fragID": "time",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"timer": {
+	  "name": "timer",
+	  "fragID": "timer",
+	  "parentRoles": [
+		"status"
+	  ],
+	  "localprops": []
+	},
+	"toolbar": {
+	  "name": "toolbar",
+	  "fragID": "toolbar",
+	  "parentRoles": [
+		"group"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"tooltip": {
+	  "name": "tooltip",
+	  "fragID": "tooltip",
+	  "parentRoles": [
+		"section"
+	  ],
+	  "localprops": []
+	},
+	"tree": {
+	  "name": "tree",
+	  "fragID": "tree",
+	  "parentRoles": [
+		"select"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-multiselectable",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-required",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-orientation",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-activedescendant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"treegrid": {
+	  "name": "treegrid",
+	  "fragID": "treegrid",
+	  "parentRoles": [
+		"grid",
+		"tree"
+	  ],
+	  "localprops": []
+	},
+	"treeitem": {
+	  "name": "treeitem",
+	  "fragID": "treeitem",
+	  "parentRoles": [
+		"listitem",
+		"option"
+	  ],
+	  "localprops": [
+		{
+		  "is": "state",
+		  "name": "aria-expanded",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"widget": {
+	  "name": "widget",
+	  "fragID": "widget",
+	  "parentRoles": [
+		"roletype"
+	  ],
+	  "localprops": [],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	},
+	"window": {
+	  "name": "window",
+	  "fragID": "window",
+	  "parentRoles": [
+		"roletype"
+	  ],
+	  "localprops": [
+		{
+		  "is": "property",
+		  "name": "aria-modal",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ],
+	  "allprops": [
+		{
+		  "is": "property",
+		  "name": "aria-modal",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-atomic",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-busy",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-controls",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-current",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-describedby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-details",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-disabled",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-dropeffect",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-errormessage",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-flowto",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-grabbed",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-haspopup",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "state",
+		  "name": "aria-hidden",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "state",
+		  "name": "aria-invalid",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": true
+		},
+		{
+		  "is": "property",
+		  "name": "aria-keyshortcuts",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-label",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-labelledby",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-live",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-owns",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-relevant",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		},
+		{
+		  "is": "property",
+		  "name": "aria-roledescription",
+		  "required": false,
+		  "disallowed": false,
+		  "deprecated": false
+		}
+	  ]
+	}
   }
-}


### PR DESCRIPTION
This patch does nothing more than remove the use of jquery. I tried to avoid refactoring / making any unrelated changes.
 I wasn't sure which browsers we need to support so I've tried to keep everything compatible with old ones.
 
See w3c/aria/issues/1380

I still need to test that I haven't broken anything -- leaving this in draft until I've confirmed