### PR TITLE
start index at 0 and get last element

### DIFF
--- a/script/mapping-tables.js
+++ b/script/mapping-tables.js
@@ -30,9 +30,9 @@ function queryAll(selector, context) {
 
 function getElementIndex(el) {
   var i = 0;
-  do {
+  while ((el = el.previousElementSibling)) {
     i++;
-  } while ((el = el.previousElementSibling));
+  }
   return i;
 }
 


### PR DESCRIPTION
fixes a bug found while publishing HTML-AAM that causes IDs of mapping tables to be output offset by one row, with last one missing