### PR TITLE
Add missing `repository`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
+        repository: w3c/${{ matrix.repo }}
         path: ${{ matrix.repo }}
         ref: ${{ matrix.branch }}
         token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Somehow it's cloning `w3c/aria-common` twice instead of cloning the child repositories.