### PR TITLE
Trim ids when cloning descriptions 

### DIFF
--- a/script/aria.js
+++ b/script/aria.js
@@ -45,7 +45,7 @@ function ariaAttributeReferences() {
             '</span>';
           sp.setAttribute('aria-describedby', 'desc-' + title);
           var dRef = item.nextElementSibling;
-          var desc = dRef.firstElementChild.innerHTML;
+          var desc = cloneWithoutIds(dRef.firstElementChild).innerHTML;
           dRef.id = 'desc-' + title;
           dRef.setAttribute('role', 'definition');
           var heading = document.createElement('h4');
@@ -254,7 +254,7 @@ function ariaAttributeReferences() {
           // sp.id = title;
           sp.setAttribute('aria-describedby', 'desc-' + title);
           var dRef = item.nextElementSibling;
-          var desc = dRef.firstElementChild.innerHTML;
+          var desc = cloneWithoutIds(dRef.firstElementChild).innerHTML;
           dRef.id = 'desc-' + title;
           dRef.setAttribute('role', 'definition');
           container.replaceChild(sp, item);
@@ -744,6 +744,14 @@ function ariaAttributeReferences() {
         });
 
       updateReferences(document);
+
+      function cloneWithoutIds(node) {
+        const clone = node.cloneNode(true);
+        for (const elementWithId of clone.querySelectorAll("[id]")) {
+          elementWithId.removeAttribute("id");
+        }
+        return clone;
+      }
   }
 
 require(['core/pubsubhub'], function (respecEvents) {

--- a/script/aria.js
+++ b/script/aria.js
@@ -13,7 +13,6 @@
 var roleInfo = {};
 
 function ariaAttributeReferences() {
-  {
       var propList = {};
       var globalSP = [];
 
@@ -745,7 +744,6 @@ function ariaAttributeReferences() {
         });
 
       updateReferences(document);
-    }
   }
 
 require(['core/pubsubhub'], function (respecEvents) {


### PR DESCRIPTION
ReSpec assigns ids to reference nodes, and cloning them causes id collision issue as seen in https://github.com/w3c/aria/issues/1623#issuecomment-953903263. This workarounds the issue.