### PR TITLE
Fix buttons, 'expand all' should only expand all in section

### DIFF
--- a/script/mapping-tables.js
+++ b/script/mapping-tables.js
@@ -249,7 +249,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelectorAll('button.expand').forEach(function (b){
     b.addEventListener('click', function () {
-      detailsContainer = b.parentElement.querySelector('.details');
+      detailsContainer = b.parentElement;
       expandCollapseDetails(detailsContainer, 'expand');
       b.disabled = true;
       b.parentElement
@@ -260,7 +260,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelectorAll('button.collapse').forEach(function (b){
     b.addEventListener('click', function () {
-      detailsContainer = b.parentElement.querySelector('.details');
+      detailsContainer = b.parentElement;
       expandCollapseDetails(detailsContainer, 'collapse');
       b.disabled = true;
       b.parentElement


### PR DESCRIPTION
Currently, the buttons "expand all" expand all the drop downs in the whole document. This fixes them to their intended use (expanding only all the expandable elements in the specific section).